### PR TITLE
Update code after repo transfer

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -1,7 +1,7 @@
 domain: samba.org
 layout: go.kubebuilder.io/v2
 projectName: samba-operator
-repo: github.com/obnoxxx/samba-operator
+repo: github.com/samba-in-kubernetes/samba-operator
 resources:
 - group: samba-operator
   kind: SmbService

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ you'll be running this as a normal user.
 ## Containers on quay.io
 
 This operator uses the container built from
-[obnoxxx/samba-container](https://github.com/obnoxxx/samba-container)
+[samba-in-kubernetes/samba-container](https://github.com/samba-in-kubernetes/samba-container)
 as found on [quay.io](https://quay.io/repository/obnox/samba-centos8).
 
 The container from this codebase is published on

--- a/controllers/smbpvc_controller.go
+++ b/controllers/smbpvc_controller.go
@@ -25,8 +25,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	sambaoperatorv1alpha1 "github.com/obnoxxx/samba-operator/api/v1alpha1"
-	"github.com/obnoxxx/samba-operator/internal/resources"
+	sambaoperatorv1alpha1 "github.com/samba-in-kubernetes/samba-operator/api/v1alpha1"
+	"github.com/samba-in-kubernetes/samba-operator/internal/resources"
 )
 
 // SmbPvcReconciler reconciles a SmbPvc object

--- a/controllers/smbservice_controller.go
+++ b/controllers/smbservice_controller.go
@@ -25,8 +25,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	sambaoperatorv1alpha1 "github.com/obnoxxx/samba-operator/api/v1alpha1"
-	"github.com/obnoxxx/samba-operator/internal/resources"
+	sambaoperatorv1alpha1 "github.com/samba-in-kubernetes/samba-operator/api/v1alpha1"
+	"github.com/samba-in-kubernetes/samba-operator/internal/resources"
 )
 
 // SmbServiceReconciler reconciles a SmbService object

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -30,7 +30,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	sambaoperatorv1alpha1 "github.com/obnoxxx/samba-operator/api/v1alpha1"
+	sambaoperatorv1alpha1 "github.com/samba-in-kubernetes/samba-operator/api/v1alpha1"
 	// +kubebuilder:scaffold:imports
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/obnoxxx/samba-operator
+module github.com/samba-in-kubernetes/samba-operator
 
 go 1.13
 

--- a/internal/resources/smbpvc.go
+++ b/internal/resources/smbpvc.go
@@ -18,7 +18,7 @@ package resources
 import (
 	"context"
 
-	sambaoperatorv1alpha1 "github.com/obnoxxx/samba-operator/api/v1alpha1"
+	sambaoperatorv1alpha1 "github.com/samba-in-kubernetes/samba-operator/api/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"

--- a/internal/resources/smbservice.go
+++ b/internal/resources/smbservice.go
@@ -28,8 +28,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	sambaoperatorv1alpha1 "github.com/obnoxxx/samba-operator/api/v1alpha1"
-	"github.com/obnoxxx/samba-operator/internal/conf"
+	sambaoperatorv1alpha1 "github.com/samba-in-kubernetes/samba-operator/api/v1alpha1"
+	"github.com/samba-in-kubernetes/samba-operator/internal/conf"
 )
 
 // SmbServiceManager is used to manage SmbService resources.

--- a/main.go
+++ b/main.go
@@ -27,9 +27,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	sambaoperatorv1alpha1 "github.com/obnoxxx/samba-operator/api/v1alpha1"
-	"github.com/obnoxxx/samba-operator/controllers"
-	"github.com/obnoxxx/samba-operator/internal/conf"
+	sambaoperatorv1alpha1 "github.com/samba-in-kubernetes/samba-operator/api/v1alpha1"
+	"github.com/samba-in-kubernetes/samba-operator/controllers"
+	"github.com/samba-in-kubernetes/samba-operator/internal/conf"
 	// +kubebuilder:scaffold:imports
 )
 


### PR DESCRIPTION
After transfer of the org from obnoxxx to samba-in-kubernetes org,
the code needs to be adapted. It seems this needs to be done in
several steps, because the go.mod part refers to the committed code.

Signed-off-by: Michael Adam <obnox@redhat.com>