### PR TITLE
api: set proper defaults for our share booleans

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,9 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 # Image URL to use all building/pushing image targets
 TAG ?= latest
 IMG ?= quay.io/samba.org/samba-operator:$(TAG)
-# Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
-CRD_OPTIONS ?= "crd:trivialVersions=true"
+
+# Produce CRDs that work on Kubernetes 1.16 or later
+CRD_OPTIONS ?= "crd:trivialVersions=true,crdVersions=v1"
 
 CHECK_GOFMT_FLAGS ?= -e -s -l
 

--- a/api/v1alpha1/smbshare_types.go
+++ b/api/v1alpha1/smbshare_types.go
@@ -39,11 +39,13 @@ type SmbShareSpec struct {
 	Storage SmbShareStorageSpec `json:"storage"`
 
 	// ReadOnly controls if this share is to be read-only or not.
+	// +kubebuilder:default:=false
 	// +optional
 	ReadOnly bool `json:"readOnly"`
 
 	// Browseable controls if the share will be browseable. A browseable share
 	// is visible in listings.
+	// +kubebuilder:default:=true
 	// +optional
 	Browseable bool `json:"browseable"`
 }

--- a/config/crd/bases/samba-operator.samba.org_smbshares.yaml
+++ b/config/crd/bases/samba-operator.samba.org_smbshares.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -15,193 +15,197 @@ spec:
     plural: smbshares
     singular: smbshare
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: SmbShare is the Schema for the smbshares API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: SmbShareSpec defines the desired state of SmbShare
-          properties:
-            browseable:
-              description: Browseable controls if the share will be browseable. A
-                browseable share is visible in listings.
-              type: boolean
-            readOnly:
-              description: ReadOnly controls if this share is to be read-only or not.
-              type: boolean
-            shareName:
-              description: ShareName is an optional string that lets you define an
-                SMB compliant name for the share. If unset, the name will be derived
-                automatically.
-              type: string
-            storage:
-              description: Storage defines the type and location of the storage that
-                backs this share.
-              properties:
-                pvc:
-                  description: Pvc defines PVC backed storage for this share.
-                  properties:
-                    name:
-                      description: Name of the PVC to use for the share.
-                      type: string
-                    spec:
-                      description: Spec defines a new, temporary, PVC to use for the
-                        share. Behaves similar to the embedded PVC spec for pods.
-                      properties:
-                        accessModes:
-                          description: 'AccessModes contains the desired access modes
-                            the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-                          items:
-                            type: string
-                          type: array
-                        dataSource:
-                          description: 'This field can be used to specify either:
-                            * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
-                            - Beta) * An existing PVC (PersistentVolumeClaim) * An
-                            existing custom resource/object that implements data population
-                            (Alpha) In order to use VolumeSnapshot object types, the
-                            appropriate feature gate must be enabled (VolumeSnapshotDataSource
-                            or AnyVolumeDataSource) If the provisioner or an external
-                            controller can support the specified data source, it will
-                            create a new volume based on the contents of the specified
-                            data source. If the specified data source is not supported,
-                            the volume will not be created and the failure will be
-                            reported as an event. In the future, we plan to support
-                            more data source types and the behavior of the provisioner
-                            may change.'
-                          properties:
-                            apiGroup:
-                              description: APIGroup is the group for the resource
-                                being referenced. If APIGroup is not specified, the
-                                specified Kind must be in the core API group. For
-                                any other third-party types, APIGroup is required.
-                              type: string
-                            kind:
-                              description: Kind is the type of resource being referenced
-                              type: string
-                            name:
-                              description: Name is the name of resource being referenced
-                              type: string
-                          required:
-                          - kind
-                          - name
-                          type: object
-                        resources:
-                          description: 'Resources represents the minimum resources
-                            the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
-                          properties:
-                            limits:
-                              additionalProperties:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Limits describes the maximum amount of
-                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                              type: object
-                            requests:
-                              additionalProperties:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Requests describes the minimum amount
-                                of compute resources required. If Requests is omitted
-                                for a container, it defaults to Limits if that is
-                                explicitly specified, otherwise to an implementation-defined
-                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                              type: object
-                          type: object
-                        selector:
-                          description: A label query over volumes to consider for
-                            binding.
-                          properties:
-                            matchExpressions:
-                              description: matchExpressions is a list of label selector
-                                requirements. The requirements are ANDed.
-                              items:
-                                description: A label selector requirement is a selector
-                                  that contains values, a key, and an operator that
-                                  relates the key and values.
-                                properties:
-                                  key:
-                                    description: key is the label key that the selector
-                                      applies to.
-                                    type: string
-                                  operator:
-                                    description: operator represents a key's relationship
-                                      to a set of values. Valid operators are In,
-                                      NotIn, Exists and DoesNotExist.
-                                    type: string
-                                  values:
-                                    description: values is an array of string values.
-                                      If the operator is In or NotIn, the values array
-                                      must be non-empty. If the operator is Exists
-                                      or DoesNotExist, the values array must be empty.
-                                      This array is replaced during a strategic merge
-                                      patch.
-                                    items:
-                                      type: string
-                                    type: array
-                                required:
-                                - key
-                                - operator
-                                type: object
-                              type: array
-                            matchLabels:
-                              additionalProperties:
-                                type: string
-                              description: matchLabels is a map of {key,value} pairs.
-                                A single {key,value} in the matchLabels map is equivalent
-                                to an element of matchExpressions, whose key field
-                                is "key", the operator is "In", and the values array
-                                contains only "value". The requirements are ANDed.
-                              type: object
-                          type: object
-                        storageClassName:
-                          description: 'Name of the StorageClass required by the claim.
-                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
-                          type: string
-                        volumeMode:
-                          description: volumeMode defines what type of volume is required
-                            by the claim. Value of Filesystem is implied when not
-                            included in claim spec.
-                          type: string
-                        volumeName:
-                          description: VolumeName is the binding reference to the
-                            PersistentVolume backing this claim.
-                          type: string
-                      type: object
-                  type: object
-              type: object
-          required:
-          - storage
-          type: object
-        status:
-          description: SmbShareStatus defines the observed state of SmbShare
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: SmbShare is the Schema for the smbshares API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SmbShareSpec defines the desired state of SmbShare
+            properties:
+              browseable:
+                default: true
+                description: Browseable controls if the share will be browseable.
+                  A browseable share is visible in listings.
+                type: boolean
+              readOnly:
+                default: false
+                description: ReadOnly controls if this share is to be read-only or
+                  not.
+                type: boolean
+              shareName:
+                description: ShareName is an optional string that lets you define
+                  an SMB compliant name for the share. If unset, the name will be
+                  derived automatically.
+                type: string
+              storage:
+                description: Storage defines the type and location of the storage
+                  that backs this share.
+                properties:
+                  pvc:
+                    description: Pvc defines PVC backed storage for this share.
+                    properties:
+                      name:
+                        description: Name of the PVC to use for the share.
+                        type: string
+                      spec:
+                        description: Spec defines a new, temporary, PVC to use for
+                          the share. Behaves similar to the embedded PVC spec for
+                          pods.
+                        properties:
+                          accessModes:
+                            description: 'AccessModes contains the desired access
+                              modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                            items:
+                              type: string
+                            type: array
+                          dataSource:
+                            description: 'This field can be used to specify either:
+                              * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
+                              - Beta) * An existing PVC (PersistentVolumeClaim) *
+                              An existing custom resource/object that implements data
+                              population (Alpha) In order to use VolumeSnapshot object
+                              types, the appropriate feature gate must be enabled
+                              (VolumeSnapshotDataSource or AnyVolumeDataSource) If
+                              the provisioner or an external controller can support
+                              the specified data source, it will create a new volume
+                              based on the contents of the specified data source.
+                              If the specified data source is not supported, the volume
+                              will not be created and the failure will be reported
+                              as an event. In the future, we plan to support more
+                              data source types and the behavior of the provisioner
+                              may change.'
+                            properties:
+                              apiGroup:
+                                description: APIGroup is the group for the resource
+                                  being referenced. If APIGroup is not specified,
+                                  the specified Kind must be in the core API group.
+                                  For any other third-party types, APIGroup is required.
+                                type: string
+                              kind:
+                                description: Kind is the type of resource being referenced
+                                type: string
+                              name:
+                                description: Name is the name of resource being referenced
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                          resources:
+                            description: 'Resources represents the minimum resources
+                              the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount
+                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount
+                                  of compute resources required. If Requests is omitted
+                                  for a container, it defaults to Limits if that is
+                                  explicitly specified, otherwise to an implementation-defined
+                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                type: object
+                            type: object
+                          selector:
+                            description: A label query over volumes to consider for
+                              binding.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                          storageClassName:
+                            description: 'Name of the StorageClass required by the
+                              claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                            type: string
+                          volumeMode:
+                            description: volumeMode defines what type of volume is
+                              required by the claim. Value of Filesystem is implied
+                              when not included in claim spec.
+                            type: string
+                          volumeName:
+                            description: VolumeName is the binding reference to the
+                              PersistentVolume backing this claim.
+                            type: string
+                        type: object
+                    type: object
+                type: object
+            required:
+            - storage
+            type: object
+          status:
+            description: SmbShareStatus defines the observed state of SmbShare
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
Use the "annotations" provided by kubebuilder to specify how to treat the boolean values when they're not explicitly set.