### PR TITLE
Introduce share planner and configmap

### DIFF
--- a/internal/resources/configmap.go
+++ b/internal/resources/configmap.go
@@ -1,0 +1,106 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"context"
+	"encoding/json"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/samba-in-kubernetes/samba-operator/internal/smbcc"
+)
+
+const (
+	// ConfigMapName is the name of the configmap we store in.
+	ConfigMapName = "samba-container-config"
+	// ConfigJSONKey is the name of the key our json is under.
+	ConfigJSONKey = "config.json"
+)
+
+func getOrCreateConfigMap(
+	ctx context.Context, client client.Client, ns string) (
+	*corev1.ConfigMap, bool, error) {
+	// fetch the existing config, if available
+	cm := &corev1.ConfigMap{}
+	err := client.Get(
+		ctx,
+		types.NamespacedName{
+			Name:      ConfigMapName,
+			Namespace: ns,
+		},
+		cm)
+	if err == nil {
+		return cm, false, nil
+	}
+
+	if errors.IsNotFound(err) {
+		cm, err = newDefaultConfigMap(ConfigMapName, ns)
+		if err != nil {
+			return cm, false, err
+		}
+		err = client.Create(ctx, cm)
+		if err != nil {
+			return cm, false, err
+		}
+		// Deployment created successfully
+		return cm, true, nil
+	}
+	return nil, false, err
+}
+
+func newDefaultConfigMap(name, ns string) (*corev1.ConfigMap, error) {
+	// we use marshal indent so that the json is semi-human-readable
+	// so that debugging is not so tedious.
+	jb, err := json.MarshalIndent(smbcc.New(), "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	data := map[string]string{ConfigJSONKey: string(jb)}
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Data: data,
+	}
+	return cm, nil
+}
+
+func getContainerConfig(cm *corev1.ConfigMap) (*smbcc.SambaContainerConfig, error) {
+	cc := smbcc.New()
+	jstr, found := cm.Data[ConfigJSONKey]
+	if !found {
+		return cc, nil
+	}
+	if err := json.Unmarshal([]byte(jstr), cc); err != nil {
+		return nil, err
+	}
+	return cc, nil
+}
+
+func setContainerConfig(cm *corev1.ConfigMap, cc *smbcc.SambaContainerConfig) error {
+	jb, err := json.MarshalIndent(cc, "", "  ")
+	if err != nil {
+		return err
+	}
+	cm.Data[ConfigJSONKey] = string(jb)
+	return nil
+}

--- a/internal/resources/planner.go
+++ b/internal/resources/planner.go
@@ -1,0 +1,91 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	sambaoperatorv1alpha1 "github.com/samba-in-kubernetes/samba-operator/api/v1alpha1"
+	"github.com/samba-in-kubernetes/samba-operator/internal/smbcc"
+)
+
+type sharePlanner struct {
+	SmbShare *sambaoperatorv1alpha1.SmbShare
+	Config   *smbcc.SambaContainerConfig
+}
+
+func newSharePlanner(
+	share *sambaoperatorv1alpha1.SmbShare,
+	config *smbcc.SambaContainerConfig) *sharePlanner {
+	// return a new sharePlanner
+	return &sharePlanner{
+		SmbShare: share,
+		Config:   config,
+	}
+}
+
+func (sp *sharePlanner) instanceName() string {
+	// for now, its just the name of the k8s resource
+	return sp.SmbShare.Name
+}
+
+func (sp *sharePlanner) instanceID() smbcc.Key {
+	return smbcc.Key(sp.instanceName())
+}
+
+func (sp *sharePlanner) shareName() string {
+	// todo: make sure this is smb-conf clean, otherwise we need to
+	// fix up the name value(s).
+	if sp.SmbShare.Spec.ShareName != "" {
+		return sp.SmbShare.Spec.ShareName
+	}
+	return "share"
+}
+
+func (*sharePlanner) sharePath() string {
+	// for now, everything mounts at /share
+	return "/share"
+}
+
+func (sp *sharePlanner) update() (changed bool, err error) {
+	noprinting, found := sp.Config.Globals[smbcc.NoPrintingKey]
+	if !found {
+		noprinting = smbcc.NewNoPrintingGlobals()
+		sp.Config.Globals[smbcc.NoPrintingKey] = noprinting
+		changed = true
+	}
+	shareKey := smbcc.Key(sp.shareName())
+	share, found := sp.Config.Shares[shareKey]
+	if !found {
+		share = smbcc.NewSimpleShare(sp.sharePath())
+		sp.Config.Shares[shareKey] = share
+		changed = true
+	}
+	cfgKey := sp.instanceID()
+	cfg, found := sp.Config.Configs[cfgKey]
+	if !found || cfg.Shares[0] != shareKey {
+		cfg = smbcc.ConfigSection{
+			Shares:       []smbcc.Key{shareKey},
+			Globals:      []smbcc.Key{smbcc.NoPrintingKey},
+			InstanceName: sp.instanceName(),
+		}
+		sp.Config.Configs[cfgKey] = cfg
+		changed = true
+	}
+	if len(sp.Config.Users) == 0 {
+		sp.Config.Users = smbcc.NewDefaultUsers()
+		changed = true
+	}
+	return
+}

--- a/internal/resources/smbshare.go
+++ b/internal/resources/smbshare.go
@@ -61,17 +61,22 @@ func (m *SmbShareManager) Update(ctx context.Context, nsname types.NamespacedNam
 		// Error reading the object - requeue the request.
 		return Result{err: err}
 	}
+	m.logger.Info("Updating state for SmbShare",
+		"name", instance.Name,
+		"UID", instance.UID)
 
 	cm, created, err := getOrCreateConfigMap(ctx, m.client, instance.Namespace)
 	if err != nil {
 		return Result{err: err}
 	} else if created {
+		m.logger.Info("Created config map")
 		return Requeue
 	}
 	changed, err := m.updateConfiguration(ctx, cm, instance)
 	if err != nil {
 		return Result{err: err}
 	} else if changed {
+		m.logger.Info("Updated config map")
 		return Requeue
 	}
 
@@ -81,6 +86,7 @@ func (m *SmbShareManager) Update(ctx context.Context, nsname types.NamespacedNam
 		if err != nil {
 			return Result{err: err}
 		} else if created {
+			m.logger.Info("Created PVC")
 			return Requeue
 		}
 		// if name is unset in the YAML, set it here
@@ -93,6 +99,7 @@ func (m *SmbShareManager) Update(ctx context.Context, nsname types.NamespacedNam
 		return Result{err: err}
 	} else if created {
 		// Deployment created successfully - return and requeue
+		m.logger.Info("Created deployment")
 		return Requeue
 	}
 
@@ -100,9 +107,11 @@ func (m *SmbShareManager) Update(ctx context.Context, nsname types.NamespacedNam
 	if err != nil {
 		return Result{err: err}
 	} else if resized {
+		m.logger.Info("Resized deployment")
 		return Requeue
 	}
 
+	m.logger.Info("Done updating SmbShare resources")
 	return Done
 }
 


### PR DESCRIPTION
The configmap contains a json based configuration file that is consumed by the sambacc library. This is used to initialize the container and configure samba. The share planner is a new type created to manage "knowledge" about this configuration and the exceptions about containerized samba w/o directly interacting with kubernetes constructs.

Some logging is also added as the number of steps the update function takes is begging to increase.

Based on PR #33 . Please review that first.