### PR TITLE
controllers: fix rbac annotation to include config maps

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -21,6 +21,18 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - persistentvolumeclaims
   verbs:
   - create

--- a/controllers/smbshare_controller.go
+++ b/controllers/smbshare_controller.go
@@ -42,6 +42,7 @@ type SmbShareReconciler struct {
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list
 // +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile SmbShare resources.
 func (r *SmbShareReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {


### PR DESCRIPTION
The operator tries to manage configmap(s) for the samba container
configuration. Without this change, a proper deployment of the operator
will not function because the operator can not access said configmaps.

Signed-off-by: John Mulligan <jmulligan@redhat.com>