### PR TITLE
Push towards making the integration tests more self sufficent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ ifeq ($(CONTAINER_CMD),)
 	CONTAINER_CMD:=$(shell podman version >/dev/null 2>&1 && echo podman)
 endif
 
-all: manager
+all: manager build-integration-tests
 
 # Run tests
 test: generate vet manifests
@@ -48,6 +48,10 @@ manager: generate vet build
 build:
 	go build -o bin/manager main.go
 .PHONY: build
+
+build-integration-tests:
+	go test -c -o bin/integration-tests -tags integration ./tests/integration
+.PHONY: build-integration-tests
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: generate vet manifests

--- a/Makefile
+++ b/Makefile
@@ -62,12 +62,15 @@ uninstall: manifests kustomize
 	$(KUSTOMIZE) build config/crd | kubectl delete -f -
 
 # Deploy controller in the configured Kubernetes cluster in ~/.kube/config
-deploy: manifests kustomize
-	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+deploy: manifests kustomize set-image
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
 
 delete-deploy: manifests kustomize
 	$(KUSTOMIZE) build config/default | kubectl delete -f -
+
+set-image: kustomize
+	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+.PHONY: set-image
 
 # Generate manifests e.g. CRD, RBAC etc.
 manifests: controller-gen

--- a/tests/integration/common_test.go
+++ b/tests/integration/common_test.go
@@ -6,11 +6,20 @@ import (
 	"os"
 )
 
-var testNamespace = "samba-operator-system"
+var (
+	testNamespace = "samba-operator-system"
+
+	testFilesDir = "../files"
+)
 
 func init() {
 	ns := os.Getenv("SMBOP_TEST_NAMESPACE")
 	if ns != "" {
 		testNamespace = ns
+	}
+
+	fdir := os.Getenv("SMBOP_TEST_FILES_DIR")
+	if ns != "" {
+		testFilesDir = fdir
 	}
 }

--- a/tests/integration/common_test.go
+++ b/tests/integration/common_test.go
@@ -9,7 +9,10 @@ import (
 var (
 	testNamespace = "samba-operator-system"
 
-	testFilesDir = "../files"
+	testFilesDir      = "../files"
+	operatorConfigDir = "../../config"
+
+	kustomizeCmd = "kustomize"
 )
 
 func init() {
@@ -19,7 +22,21 @@ func init() {
 	}
 
 	fdir := os.Getenv("SMBOP_TEST_FILES_DIR")
-	if ns != "" {
+	if fdir != "" {
 		testFilesDir = fdir
+	}
+
+	cdir := os.Getenv("SMBOP_TEST_CONFIG_DIR")
+	if cdir != "" {
+		operatorConfigDir = cdir
+	}
+
+	km := os.Getenv("SMBOP_TEST_KUSTOMIZE")
+	if km != "" {
+		kustomizeCmd = km
+	}
+	km2 := os.Getenv("KUSTOMIZE")
+	if km == "" && km2 != "" {
+		kustomizeCmd = km2
 	}
 }

--- a/tests/integration/common_test.go
+++ b/tests/integration/common_test.go
@@ -13,6 +13,8 @@ var (
 	operatorConfigDir = "../../config"
 
 	kustomizeCmd = "kustomize"
+
+	testExpectedImage = "quay.io/samba.org/samba-operator:latest"
 )
 
 func init() {
@@ -38,5 +40,10 @@ func init() {
 	km2 := os.Getenv("KUSTOMIZE")
 	if km == "" && km2 != "" {
 		kustomizeCmd = km2
+	}
+
+	timg := os.Getenv("SMBOP_TEST_EXPECT_MANAGER_IMG")
+	if timg != "" {
+		testExpectedImage = timg
 	}
 }

--- a/tests/integration/deploy_test.go
+++ b/tests/integration/deploy_test.go
@@ -1,0 +1,75 @@
+// +build integration
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"path"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/samba-in-kubernetes/samba-operator/tests/utils/kube"
+)
+
+type DeploySuite struct {
+	suite.Suite
+
+	sharedConfigDir string
+
+	// cached values
+	tc *kube.TestClient
+}
+
+// SetupSuite sets up (deploys) the operator.
+func (s *DeploySuite) SetupSuite() {
+	s.tc = kube.NewTestClient("")
+	s.createKustomized(s.sharedConfigDir)
+}
+
+func (s DeploySuite) createKustomized(dir string) {
+	cmd := exec.Command(kustomizeCmd, "build", dir)
+	stdout, err := cmd.StdoutPipe()
+	s.Require().NoError(err)
+	err = cmd.Start()
+	s.Require().NoError(err)
+	_, err = s.tc.CreateFromFileIfMissing(
+		context.TODO(),
+		kube.DirectSource{
+			Source:    stdout,
+			Namespace: testNamespace,
+		},
+	)
+	s.Require().NoError(err)
+	err = cmd.Wait()
+	s.Require().NoError(err)
+}
+
+func (s DeploySuite) TestOperatorReady() {
+	ctx, cancel := context.WithDeadline(
+		context.TODO(),
+		time.Now().Add(90*time.Second))
+	defer cancel()
+	err := kube.WaitForPodExistsByLabel(
+		ctx,
+		s.tc,
+		fmt.Sprintf("control-plane=controller-manager"),
+		testNamespace)
+	s.Require().NoError(err)
+	err = kube.WaitForPodReadyByLabel(
+		ctx,
+		s.tc,
+		fmt.Sprintf("control-plane=controller-manager"),
+		testNamespace)
+	s.Require().NoError(err)
+}
+
+func allDeploySuites() map[string]suite.TestingSuite {
+	m := map[string]suite.TestingSuite{}
+	m["default"] = &DeploySuite{
+		sharedConfigDir: path.Join(operatorConfigDir, "default"),
+	}
+	return m
+}

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -19,5 +19,6 @@ func runSuiteTests(sm map[string]suite.TestingSuite) func(t *testing.T) {
 }
 
 func TestIntegration(t *testing.T) {
+	t.Run("deploy", runSuiteTests(allDeploySuites()))
 	t.Run("smbShares", runSuiteTests(allSmbShareSuites()))
 }

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -1,0 +1,23 @@
+// +build integration
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+func runSuiteTests(sm map[string]suite.TestingSuite) func(t *testing.T) {
+	return func(t *testing.T) {
+		for name, ts := range sm {
+			t.Run(name, func(t *testing.T) {
+				suite.Run(t, ts)
+			})
+		}
+	}
+}
+
+func TestIntegration(t *testing.T) {
+	t.Run("smbShares", runSuiteTests(allSmbShareSuites()))
+}

--- a/tests/integration/share_access_test.go
+++ b/tests/integration/share_access_test.go
@@ -4,6 +4,7 @@ package integration
 
 import (
 	"context"
+	"path"
 	"time"
 
 	"github.com/stretchr/testify/suite"
@@ -28,14 +29,14 @@ func (s *ShareAccessSuite) SetupSuite() {
 	_, err := tc.CreateFromFileIfMissing(
 		context.TODO(),
 		kube.FileSource{
-			Path:      "../files/data1.yaml",
+			Path:      path.Join(testFilesDir, "data1.yaml"),
 			Namespace: testNamespace,
 		})
 	s.Require().NoError(err)
 	_, err = tc.CreateFromFileIfMissing(
 		context.TODO(),
 		kube.FileSource{
-			Path:      "../files/client-test-pod.yaml",
+			Path:      path.Join(testFilesDir, "client-test-pod.yaml"),
 			Namespace: testNamespace,
 		})
 	s.Require().NoError(err)

--- a/tests/integration/smb_share_test.go
+++ b/tests/integration/smb_share_test.go
@@ -5,7 +5,6 @@ package integration
 import (
 	"context"
 	"fmt"
-	"testing"
 	"time"
 
 	"github.com/stretchr/testify/suite"
@@ -109,36 +108,33 @@ func (s *SmbShareSuite) TestShareAccess() {
 	suite.Run(s.T(), shareAccessSuite)
 }
 
-func TestSmbShares(t *testing.T) {
-	t.Run("1", func(t *testing.T) {
-		smbShareSuite1 := &SmbShareSuite{
-			fileSources: []string{
-				"../files/smbsecurityconfig1.yaml",
-				"../files/smbshare1.yaml",
-			},
-			smbShareResourceName: "tshare1",
-			shareName:            "My Share",
-			testAuths: []smbclient.Auth{{
-				Username: "sambauser",
-				Password: "1nsecurely",
-			}},
-		}
-		suite.Run(t, smbShareSuite1)
-	})
+func allSmbShareSuites() map[string]suite.TestingSuite {
+	m := map[string]suite.TestingSuite{}
+	m["users1"] = &SmbShareSuite{
+		fileSources: []string{
+			"../files/smbsecurityconfig1.yaml",
+			"../files/smbshare1.yaml",
+		},
+		smbShareResourceName: "tshare1",
+		shareName:            "My Share",
+		testAuths: []smbclient.Auth{{
+			Username: "sambauser",
+			Password: "1nsecurely",
+		}},
+	}
 
-	t.Run("2", func(t *testing.T) {
-		smbShareSuite2 := &SmbShareSuite{
-			fileSources: []string{
-				"../files/smbsecurityconfig2.yaml",
-				"../files/smbshare2.yaml",
-			},
-			smbShareResourceName: "tshare2",
-			shareName:            "My Kingdom",
-			testAuths: []smbclient.Auth{{
-				Username: "DOMAIN1\\bwayne",
-				Password: "1115Rose.",
-			}},
-		}
-		suite.Run(t, smbShareSuite2)
-	})
+	m["domainMember1"] = &SmbShareSuite{
+		fileSources: []string{
+			"../files/smbsecurityconfig2.yaml",
+			"../files/smbshare2.yaml",
+		},
+		smbShareResourceName: "tshare2",
+		shareName:            "My Kingdom",
+		testAuths: []smbclient.Auth{{
+			Username: "DOMAIN1\\bwayne",
+			Password: "1115Rose.",
+		}},
+	}
+
+	return m
 }

--- a/tests/integration/smb_share_test.go
+++ b/tests/integration/smb_share_test.go
@@ -5,6 +5,7 @@ package integration
 import (
 	"context"
 	"fmt"
+	"path"
 	"time"
 
 	"github.com/stretchr/testify/suite"
@@ -112,8 +113,8 @@ func allSmbShareSuites() map[string]suite.TestingSuite {
 	m := map[string]suite.TestingSuite{}
 	m["users1"] = &SmbShareSuite{
 		fileSources: []string{
-			"../files/smbsecurityconfig1.yaml",
-			"../files/smbshare1.yaml",
+			path.Join(testFilesDir, "smbsecurityconfig1.yaml"),
+			path.Join(testFilesDir, "smbshare1.yaml"),
 		},
 		smbShareResourceName: "tshare1",
 		shareName:            "My Share",
@@ -125,8 +126,8 @@ func allSmbShareSuites() map[string]suite.TestingSuite {
 
 	m["domainMember1"] = &SmbShareSuite{
 		fileSources: []string{
-			"../files/smbsecurityconfig2.yaml",
-			"../files/smbshare2.yaml",
+			path.Join(testFilesDir, "smbsecurityconfig2.yaml"),
+			path.Join(testFilesDir, "smbshare2.yaml"),
 		},
 		smbShareResourceName: "tshare2",
 		shareName:            "My Kingdom",

--- a/tests/utils/kube/dynamic.go
+++ b/tests/utils/kube/dynamic.go
@@ -45,6 +45,23 @@ func (f FileSource) GetNamespace() string {
 	return f.Namespace
 }
 
+// DirectSource interfaces are used to specify k8s resources directly
+// from a ReadCloser stream.
+type DirectSource struct {
+	Source    io.ReadCloser
+	Namespace string
+}
+
+// Open returns the source.
+func (d DirectSource) Open() (io.ReadCloser, error) {
+	return d.Source, nil
+}
+
+// GetNamespace returns the specified namespace.
+func (d DirectSource) GetNamespace() string {
+	return d.Namespace
+}
+
 // CreateFromFile creates new resources given a (yaml) file input.
 // It returns an error if the resource already exists.
 func (tc *TestClient) CreateFromFile(


### PR DESCRIPTION
These changes work towards making the Go(lang) parts of the test suite able to launch and verify the samba operator.

A lot of the patches simply add infrastructure to allow running the various "phases" of the integration test in order, as well as teaching the tests how to make use of kustomize so that they don't need to actually execute make (ick, :-)).

Unfortunately, these changes do not entirely stand on their own (yet). Certain aspects of the current build process appear to be working due to side effects (or something) and so I can not yet remove the rule that executes make deploy in the CI. Once I understand how to use k3d in the CI more betterer I think we can adapt the CI o rely only on the built artifacts.