### PR TITLE
makefile: add a rule for building images from buildah

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,14 @@ docker-build: image-build
 image-build:
 	$(CONTAINER_CMD) build $(CONTAINER_BUILD_OPTS) . -t ${IMG}
 
+.PHONY: image-build-buildah
+image-build-buildah: build
+	cn=$$(buildah from registry.access.redhat.com/ubi8/ubi-minimal:latest) && \
+	buildah copy $$cn bin/manager /manager && \
+	buildah config --cmd='[]' $$cn && \
+	buildah config --entrypoint='["/manager"]' $$cn && \
+	buildah commit $$cn ${IMG}
+
 # Push the container image
 docker-push: container-push
 container-push:


### PR DESCRIPTION
The new `image-build-buildah` rule can be used to quickly create a
minimal image from the exact `manager` binary. While this is not
recommended for production or release builds, it can be handy for a
developer working on quick build-and-test iterations and
experimentation.

Signed-off-by: John Mulligan <jmulligan@redhat.com>