### PR TITLE
deploy: increase memory limit to 100Mi for the manager

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -33,7 +33,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 30Mi
+            memory: 100Mi
           requests:
             cpu: 100m
             memory: 20Mi


### PR DESCRIPTION
When running on OpenShift (where the resource limits are enforced by
default), the manager container gets OOM killed. It seems that the limit
of 30Mi is too low, when starting the container consumes close to 70Mi
after which it reduces back to 40Mi.

Fixes: #56