### PR TITLE
deploy/rbac: allow the controller to set smbshares/finalizers

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -84,6 +84,14 @@ rules:
 - apiGroups:
   - samba-operator.samba.org
   resources:
+  - smbshares/finalizers
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - samba-operator.samba.org
+  resources:
   - smbshares/status
   verbs:
   - get

--- a/controllers/smbshare_controller.go
+++ b/controllers/smbshare_controller.go
@@ -38,6 +38,7 @@ type SmbShareReconciler struct {
 }
 
 // +kubebuilder:rbac:groups=samba-operator.samba.org,resources=smbshares,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=samba-operator.samba.org,resources=smbshares/finalizers,verbs=get;update;patch
 // +kubebuilder:rbac:groups=samba-operator.samba.org,resources=smbshares/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list


### PR DESCRIPTION
Creating an SmbShare on OpenShift fails with

    Failed to create new PVC	{"smbshare": "samba-operator-system/tshare1", "pvc.Namespace": "samba-operator-system", "pvc.Name": "tshare1-pvc", "error": "persistentvolumeclaims \"tshare1-pvc\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>"}

This is caused by the OwnerReferencesPermissionEnforcement plugin that
is enabled by default on OpenShift.

By adding the permissions for the controller to set finalizers on the
SmbShare resource, this problem does not occur anymore.

Updates: #11