### PR TITLE
dockerfile: use an up-to-date golang builder image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.13 as builder
+FROM golang:1.16 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
The build image was created in the olden days and has not been updated
in a while. So it is not using a currently supported version of golang.
This updates it to the latest golang version.
