### PR TITLE
Namespace behavior improvements

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -30,6 +30,11 @@ spec:
         - /manager
         args:
         - --enable-leader-election
+        env:
+        - name: SAMBA_OP_WORKING_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: controller:latest
         imagePullPolicy: Always
         name: manager

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -14,6 +14,19 @@ import (
 type OperatorConfig struct {
 	SmbdContainerImage string `mapstructure:"smbd-container-image"`
 	SmbdContainerName  string `mapstructure:"smbd-container-name"`
+	WorkingNamespace   string `mapstructure:"working-namespace"`
+}
+
+// Validate the OperatorConfig returning an error if the config is not
+// directly usable by the operator. This may occur if certain required
+// values are unset or invalid.
+func (oc *OperatorConfig) Validate() error {
+	// Ensure that WorkingNamespace is set. We don't default it to anything.
+	// It must be passed in, typically by the operator's own pod spec.
+	if oc.WorkingNamespace == "" {
+		return fmt.Errorf("WorkingNamespace value [%s] invalid", oc.WorkingNamespace)
+	}
+	return nil
 }
 
 // Source is how external configuration sources populate the operator config.
@@ -27,6 +40,7 @@ func NewSource() *Source {
 	v := viper.New()
 	v.SetDefault("smbd-container-image", "quay.io/samba.org/samba-server:latest")
 	v.SetDefault("smbd-container-name", "samba")
+	v.SetDefault("working-namespace", "")
 	return &Source{v: v}
 }
 

--- a/internal/resources/smbshare.go
+++ b/internal/resources/smbshare.go
@@ -251,10 +251,12 @@ func (m *SmbShareManager) getOrCreatePvc(ctx context.Context,
 	if errors.IsNotFound(err) {
 		// not found - define a new pvc
 		pvc = m.pvcForSmbShare(smbShare, ns)
-		m.logger.Info("Creating a new Pvc", "Pvc.Name", pvc.Name)
+		m.logger.Info("Creating a new PVC",
+			"pvc.Namespace", pvc.Namespace, "pvc.Name", pvc.Name)
 		err = m.client.Create(ctx, pvc)
 		if err != nil {
-			m.logger.Error(err, "Failed to create new PVC", "pvc.Namespace", pvc.Namespace, "pvc.Name", pvc.Name)
+			m.logger.Error(err, "Failed to create new PVC",
+				"pvc.Namespace", pvc.Namespace, "pvc.Name", pvc.Name)
 			return pvc, false, err
 		}
 		// Pvc created successfully

--- a/internal/resources/smbshare.go
+++ b/internal/resources/smbshare.go
@@ -109,7 +109,8 @@ func (m *SmbShareManager) Update(ctx context.Context, instance *sambaoperatorv1a
 		return Requeue
 	}
 
-	cm, created, err := getOrCreateConfigMap(ctx, m.client, instance.Namespace)
+	destNamespace := m.cfg.WorkingNamespace
+	cm, created, err := getOrCreateConfigMap(ctx, m.client, destNamespace)
 	if err != nil {
 		return Result{err: err}
 	} else if created {
@@ -126,7 +127,7 @@ func (m *SmbShareManager) Update(ctx context.Context, instance *sambaoperatorv1a
 
 	if shareNeedsPvc(instance) {
 		pvc, created, err := m.getOrCreatePvc(
-			ctx, instance, instance.Namespace)
+			ctx, instance, destNamespace)
 		if err != nil {
 			return Result{err: err}
 		} else if created {
@@ -142,7 +143,7 @@ func (m *SmbShareManager) Update(ctx context.Context, instance *sambaoperatorv1a
 	}
 
 	deployment, created, err := m.getOrCreateDeployment(
-		ctx, planner, instance.Namespace)
+		ctx, planner, destNamespace)
 	if err != nil {
 		return Result{err: err}
 	} else if created {
@@ -164,7 +165,7 @@ func (m *SmbShareManager) Update(ctx context.Context, instance *sambaoperatorv1a
 	}
 
 	_, created, err = m.getOrCreateService(
-		ctx, planner, instance.Namespace)
+		ctx, planner, destNamespace)
 	if err != nil {
 		return Result{err: err}
 	} else if created {
@@ -180,7 +181,7 @@ func (m *SmbShareManager) Update(ctx context.Context, instance *sambaoperatorv1a
 // and we need to do some cleanup.
 func (m *SmbShareManager) Finalize(ctx context.Context, instance *sambaoperatorv1alpha1.SmbShare) Result {
 
-	cm, err := getConfigMap(ctx, m.client, instance.Namespace)
+	cm, err := getConfigMap(ctx, m.client, m.cfg.WorkingNamespace)
 	if err == nil {
 		_, changed, err := m.updateConfiguration(ctx, cm, instance)
 		if err != nil {

--- a/internal/resources/smbshare.go
+++ b/internal/resources/smbshare.go
@@ -241,7 +241,7 @@ func (m *SmbShareManager) getOrCreatePvc(ctx context.Context,
 		ctx,
 		types.NamespacedName{
 			Name:      pvcName(smbShare),
-			Namespace: smbShare.Namespace,
+			Namespace: ns,
 		},
 		pvc)
 	if err == nil {

--- a/internal/resources/smbshare.go
+++ b/internal/resources/smbshare.go
@@ -40,6 +40,7 @@ type SmbShareManager struct {
 	scheme   *runtime.Scheme
 	recorder record.EventRecorder
 	logger   Logger
+	cfg      *conf.OperatorConfig
 }
 
 // NewSmbShareManager creates a SmbShareManager.
@@ -51,6 +52,7 @@ func NewSmbShareManager(
 		scheme:   scheme,
 		recorder: recorder,
 		logger:   logger,
+		cfg:      conf.Get(),
 	}
 }
 
@@ -286,12 +288,8 @@ func (m *SmbShareManager) updateDeploymentSize(ctx context.Context,
 
 // deploymentForSmbShare returns a smbshare deployment object
 func (m *SmbShareManager) deploymentForSmbShare(planner *sharePlanner, ns string) *appsv1.Deployment {
-	// TODO: it is not the best to be grabbing the global conf this "deep" in
-	// the operator, but rather than refactor everything at once, we at least
-	// stop using hard coded parameters.
-	cfg := conf.Get()
 	// labels - do I need them?
-	dep := buildDeployment(cfg, planner, planner.SmbShare.Spec.Storage.Pvc.Name, ns)
+	dep := buildDeployment(m.cfg, planner, planner.SmbShare.Spec.Storage.Pvc.Name, ns)
 	// set the smbshare instance as the owner and controller
 	controllerutil.SetControllerReference(planner.SmbShare, dep, m.scheme)
 	return dep

--- a/main.go
+++ b/main.go
@@ -62,6 +62,10 @@ func main() {
 		setupLog.Error(err, "unable to configure")
 		os.Exit(1)
 	}
+	if err := conf.Get().Validate(); err != nil {
+		setupLog.Error(err, "invalid configuration")
+		os.Exit(1)
+	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:             scheme,

--- a/tests/files/joinsecret1.yaml
+++ b/tests/files/joinsecret1.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: join1
+type: Opaque
+stringData:
+  # Change the value below to match the username and password for a user that
+  # can join systems your test AD Domain
+  join.json: |
+    {"username": "Administrator", "password": "P4ssw0rd"}
+  join2.json: |
+    {"username": "Administrator", "password": "Passw0rd"}

--- a/tests/files/smbsecurityconfig1.yaml
+++ b/tests/files/smbsecurityconfig1.yaml
@@ -1,35 +1,4 @@
 ---
-apiVersion: v1
-kind: Secret
-metadata:
-  name: users1
-type: Opaque
-stringData:
-  demousers: |
-    {
-      "samba-container-config": "v0",
-      "users": {
-        "all_entries": [
-          {
-            "name": "sambauser",
-            "password": "1nsecurely"
-          },
-          {
-            "name": "alice",
-            "password": "wond3r1and"
-          },
-          {
-            "name": "bob",
-            "password": "r0b0t"
-          },
-          {
-            "name": "carol",
-            "password": "Xm4sd4y"
-          }
-        ]
-      }
-    }
----
 apiVersion: samba-operator.samba.org/v1alpha1
 kind: SmbSecurityConfig
 metadata:

--- a/tests/files/smbsecurityconfig2.yaml
+++ b/tests/files/smbsecurityconfig2.yaml
@@ -1,17 +1,4 @@
 ---
-apiVersion: v1
-kind: Secret
-metadata:
-  name: join1
-type: Opaque
-stringData:
-  # Change the value below to match the username and password for a user that
-  # can join systems your test AD Domain
-  join.json: |
-    {"username": "Administrator", "password": "P4ssw0rd"}
-  join2.json: |
-    {"username": "Administrator", "password": "Passw0rd"}
----
 apiVersion: samba-operator.samba.org/v1alpha1
 kind: SmbSecurityConfig
 metadata:

--- a/tests/files/smbshare3.yaml
+++ b/tests/files/smbshare3.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: samba-operator.samba.org/v1alpha1
+kind: SmbShare
+metadata:
+  name: tshare3
+spec:
+  shareName: "My Other Share"
+  readOnly: false
+  browseable: false
+  securityConfig: sharesec1
+  storage:
+    pvc:
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi

--- a/tests/files/userssecret1.yaml
+++ b/tests/files/userssecret1.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: users1
+type: Opaque
+stringData:
+  demousers: |
+    {
+      "samba-container-config": "v0",
+      "users": {
+        "all_entries": [
+          {
+            "name": "sambauser",
+            "password": "1nsecurely"
+          },
+          {
+            "name": "alice",
+            "password": "wond3r1and"
+          },
+          {
+            "name": "bob",
+            "password": "r0b0t"
+          },
+          {
+            "name": "carol",
+            "password": "Xm4sd4y"
+          }
+        ]
+      }
+    }

--- a/tests/integration/smb_share_test.go
+++ b/tests/integration/smb_share_test.go
@@ -206,5 +206,31 @@ func allSmbShareSuites() map[string]suite.TestingSuite {
 		}},
 	}
 
+	// Test that the operator functions when the SmbShare resources are created
+	// in a different ns (for example, "default").
+	// IMPORTANT: the secrets MUST be in the same namespace as the pods.
+	m["smbSharesInDefault"] = &SmbShareSuite{
+		fileSources: []kube.FileSource{
+			{
+				Path:      path.Join(testFilesDir, "userssecret1.yaml"),
+				Namespace: testNamespace,
+			},
+			{
+				Path:      path.Join(testFilesDir, "smbsecurityconfig1.yaml"),
+				Namespace: "default",
+			},
+			{
+				Path:      path.Join(testFilesDir, "smbshare3.yaml"),
+				Namespace: "default",
+			},
+		},
+		smbShareResource: types.NamespacedName{"default", "tshare3"},
+		shareName:        "My Other Share",
+		testAuths: []smbclient.Auth{{
+			Username: "sambauser",
+			Password: "1nsecurely",
+		}},
+	}
+
 	return m
 }

--- a/tests/utils/smbclient/smbclient.go
+++ b/tests/utils/smbclient/smbclient.go
@@ -85,10 +85,10 @@ func (ksc *kubectlSmbClientCli) Command(
 	cstring := strings.Join(shareCmd, "; ")
 	cmd := ksc.cmd(
 		ctx, auth, []string{share.String(), "-c", cstring})
-	err := cmd.Run()
+	oe, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("failed to execute smbclient command: %v: %w",
-			cmd.Args, err)
+		return fmt.Errorf("failed to execute smbclient command: %v: %w [stdio: %s]",
+			cmd.Args, err, string(oe))
 	}
 	return nil
 }


### PR DESCRIPTION
Previously, the operator created new resources in whatever namespace the     SmbShares were created in. This behavior has been changed so that     the operator keeps to one namespace, which is the one it is deployed in     by default. This is configured within the operator's deployment using the SAMBA_OP_WORKING_NAMESPACE variable.

SmbShares and SmbSecurityConfigs can still exist in any namespace. Secrets must be created in the namespace the pods will be created in. I don't like how this means you may need to create secrets and our CRs in different namespaces, but I actually don't really see a great motivation to store the CRs in a namespace other than our working namespace. But perhaps more real world use will prove me wrong.

Test added for this case.