### PR TITLE
Add samba pod and operator pod annotations for default containers

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -21,6 +21,9 @@ spec:
     metadata:
       labels:
         control-plane: controller-manager
+      annotations:
+        kubectl.kubernetes.io/default-logs-container: manager
+        kubectl.kubernetes.io/default-container: manager
     spec:
       containers:
       - command:

--- a/internal/resources/deployments.go
+++ b/internal/resources/deployments.go
@@ -45,7 +45,8 @@ func buildDeployment(cfg *conf.OperatorConfig,
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: labels,
+					Labels:      labels,
+					Annotations: annotationsForSmbPod(cfg.SmbdContainerName),
 				},
 				Spec: buildPodSpec(planner, cfg, pvcName),
 			},
@@ -78,4 +79,11 @@ func labelValue(s ...string) string {
 		out = out[:63]
 	}
 	return out
+}
+
+func annotationsForSmbPod(name string) map[string]string {
+	return map[string]string{
+		"kubectl.kubernetes.io/default-logs-container": name,
+		"kubectl.kubernetes.io/default-container":      name,
+	}
 }


### PR DESCRIPTION
Add annotations so that kubectl will have sensible defaults for both `kubectl logs` and `kubectl exec`. For the samba pod itself that's the smbd container. For the operator that the container called "manager".

Fixes #55 

See also https://github.com/kubernetes/enhancements/blob/master/keps/sig-cli/2227-kubectl-default-container/README.md