### PR TITLE
resources: add /run as writable volume

### DIFF
--- a/internal/resources/planner.go
+++ b/internal/resources/planner.go
@@ -109,6 +109,10 @@ func (*sharePlanner) sambaStateDir() string {
 	return "/var/lib/samba"
 }
 
+func (*sharePlanner) osRunDir() string {
+	return "/run"
+}
+
 func (sp *sharePlanner) securityMode() securityMode {
 	if sp.SecurityConfig == nil {
 		return userMode

--- a/internal/resources/pods.go
+++ b/internal/resources/pods.go
@@ -26,6 +26,7 @@ const (
 	userSecretVolName = "users-config"
 	wbSocketsVolName  = "samba-wb-sockets-dir"
 	stateVolName      = "samba-state-dir"
+	osRunVolName      = "run"
 	joinJsonVolName   = "join-data"
 )
 
@@ -139,6 +140,10 @@ func buildUserPodSpec(planner *sharePlanner, cfg *conf.OperatorConfig, pvcName s
 	volumes = append(volumes, configVol)
 	mounts = append(mounts, configMount)
 
+	osRunVol, osRunMount := osRunVolumeAndMount(planner)
+	volumes = append(volumes, osRunVol)
+	mounts = append(mounts, osRunMount)
+
 	if planner.securityMode() == userMode && planner.userSecuritySource().Configured {
 		v, m := userConfigVolumeAndMount(planner)
 		volumes = append(volumes, v)
@@ -248,6 +253,25 @@ func sambaStateVolumeAndMount(planner *sharePlanner) (
 	mount := corev1.VolumeMount{
 		MountPath: planner.sambaStateDir(),
 		Name:      stateVolName,
+	}
+	return volume, mount
+}
+
+func osRunVolumeAndMount(planner *sharePlanner) (
+	corev1.Volume, corev1.VolumeMount) {
+	// volume
+	volume := corev1.Volume{
+		Name: osRunVolName,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{
+				Medium: corev1.StorageMediumMemory,
+			},
+		},
+	}
+	// mount
+	mount := corev1.VolumeMount{
+		MountPath: planner.osRunDir(),
+		Name:      osRunVolName,
 	}
 	return volume, mount
 }


### PR DESCRIPTION
In OpenShift, /run is not writable for all users. This causes the Samba
service Pod to fail with the following error:

    Traceback (most recent call last):
      File "/usr/local/bin/samba-container", line 8, in <module>
        sys.exit(main())
      File "/usr/local/lib/python3.9/site-packages/sambacc/main.py", line 447, in main
        cfunc(cli, config)
      File "/usr/local/lib/python3.9/site-packages/sambacc/main.py", line 97, in run_container
        init_container(cli, config)
      File "/usr/local/lib/python3.9/site-packages/sambacc/main.py", line 84, in init_container
        import_config(cli, config)
      File "/usr/local/lib/python3.9/site-packages/sambacc/main.py", line 49, in import_config
        paths.ensure_samba_dirs()
      File "/usr/local/lib/python3.9/site-packages/sambacc/paths.py", line 37, in ensure_samba_dirs
        _mkdir(wb_sockets_dir)
      File "/usr/local/lib/python3.9/site-packages/sambacc/paths.py", line 43, in _mkdir
        os.mkdir(path)
    PermissionError: [Errno 13] Permission denied: '/run/samba/winbindd'

Adding a memory backed volume for /run makes this problem go away.