### PR TITLE
main: add version and commit id vars to binary build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # Build the manager binary
 FROM golang:1.16 as builder
+ARG GIT_VERSION="(unset)"
+ARG COMMIT_ID="(unset)"
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -16,8 +18,10 @@ COPY controllers/ controllers/
 COPY internal/ internal/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
-
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on \
+    go build -a \
+    -ldflags "-X main.Version=${GIT_VERSION} -X main.CommitID=${COMMIT_ID}" \
+    -o manager main.go
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 

--- a/main.go
+++ b/main.go
@@ -36,6 +36,11 @@ import (
 var (
 	scheme   = runtime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
+
+	// Version of the software at compile time.
+	Version = "(unset)"
+	// CommitID of the revision used to compile the software.
+	CommitID = "(unset)"
 )
 
 func init() {
@@ -93,7 +98,9 @@ func main() {
 	}
 	// +kubebuilder:scaffold:builder
 
-	setupLog.Info("starting manager")
+	setupLog.Info("starting manager",
+		"Version", Version,
+		"CommitID", CommitID)
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)


### PR DESCRIPTION
These can be used to help identify the provenance of the binary.

This is even useful if you're doing development and switching between branches and running version images and then start wondering what in heck you're actually working with. :-)