### PR TITLE
Samba container debugging

### DIFF
--- a/docs/developers-notes.md
+++ b/docs/developers-notes.md
@@ -85,3 +85,26 @@ variables in a similar manner.
 
 Please do not check changes made by kustomize to kustomization.yaml files
 in to git history.
+
+
+## Debugging the samba containers
+
+Similar to using a custom container image the operator accepts a configuration
+value for samba debugging that will be passed on to the containers the
+operator creates. This parameter is `samba-debug-level` in configuration
+files and `SAMBA_OP_SAMBA_DEBUG_LEVEL` in the evnironment. The value should
+be a numeral 0 through 10 specified as a *string*.
+
+Example setting the variable via the `./config/manager/kustomization.yaml` file:
+
+```
+patches:
+- patch: |-
+    - op: add
+      path: /spec/template/spec/containers/0/env/-
+      value:
+        name: "SAMBA_OP_SAMBA_DEBUG_LEVEL"
+        value: "8"
+  target:
+    kind: Deployment
+```

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -23,6 +23,9 @@ type OperatorConfig struct {
 	// WorkingNamespace defines the namespace the operator will (generally)
 	// make changes in.
 	WorkingNamespace string `mapstructure:"working-namespace"`
+	// SambaDebugLevel can be used to set debugging level for samba
+	// components in deployed containers.
+	SambaDebugLevel string `mapstructure:"samba-debug-level"`
 }
 
 // Validate the OperatorConfig returning an error if the config is not
@@ -50,6 +53,7 @@ func NewSource() *Source {
 	v.SetDefault("smbd-container-name", "samba")
 	v.SetDefault("working-namespace", "")
 	v.SetDefault("svc-watch-container-image", "quay.io/samba.org/svcwatch:latest")
+	v.SetDefault("samba-debug-level", "")
 	return &Source{v: v}
 }
 

--- a/internal/resources/planner.go
+++ b/internal/resources/planner.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	sambaoperatorv1alpha1 "github.com/samba-in-kubernetes/samba-operator/api/v1alpha1"
+	"github.com/samba-in-kubernetes/samba-operator/internal/conf"
 	"github.com/samba-in-kubernetes/samba-operator/internal/smbcc"
 )
 
@@ -332,4 +333,11 @@ func (sp *sharePlanner) serviceType() string {
 		return "LoadBalancer"
 	}
 	return "ClusterIP"
+}
+
+func (*sharePlanner) sambaContainerDebugLevel() string {
+	// TODO: fix this hack. The planner should incorporate all sources of config
+	// at the top level. But for now I'm taking the lazy way out.
+	cfg := conf.Get()
+	return cfg.SambaDebugLevel
 }

--- a/internal/resources/planner.go
+++ b/internal/resources/planner.go
@@ -345,9 +345,6 @@ func (sp *sharePlanner) serviceType() string {
 	return "ClusterIP"
 }
 
-func (*sharePlanner) sambaContainerDebugLevel() string {
-	// TODO: fix this hack. The planner should incorporate all sources of config
-	// at the top level. But for now I'm taking the lazy way out.
-	cfg := conf.Get()
-	return cfg.SambaDebugLevel
+func (sp *sharePlanner) sambaContainerDebugLevel() string {
+	return sp.GlobalConfig.SambaDebugLevel
 }

--- a/internal/resources/planner.go
+++ b/internal/resources/planner.go
@@ -47,24 +47,34 @@ type userSecuritySource struct {
 	Key        string
 }
 
-type sharePlanner struct {
+// InstanceConfiguration bundles together the various inputs that define
+// the configuration of a server group instance.
+type InstanceConfiguration struct {
 	SmbShare       *sambaoperatorv1alpha1.SmbShare
 	SecurityConfig *sambaoperatorv1alpha1.SmbSecurityConfig
 	CommonConfig   *sambaoperatorv1alpha1.SmbCommonConfig
-	ConfigState    *smbcc.SambaContainerConfig
+	GlobalConfig   *conf.OperatorConfig
+}
+
+type sharePlanner struct {
+	// InstanceConfiguration is used as the configuration "intent".
+	// The planner treats it as read only.
+	InstanceConfiguration
+
+	// ConfigState covers the shared configuration state that is mapped
+	// into all containers/pods and generally interpreted by sambacc
+	// for managing the behavior of samba containers. The planner treats
+	// it as read/write.
+	ConfigState *smbcc.SambaContainerConfig
 }
 
 func newSharePlanner(
-	share *sambaoperatorv1alpha1.SmbShare,
-	security *sambaoperatorv1alpha1.SmbSecurityConfig,
-	common *sambaoperatorv1alpha1.SmbCommonConfig,
-	config *smbcc.SambaContainerConfig) *sharePlanner {
+	ic InstanceConfiguration,
+	state *smbcc.SambaContainerConfig) *sharePlanner {
 	// return a new sharePlanner
 	return &sharePlanner{
-		SmbShare:       share,
-		SecurityConfig: security,
-		CommonConfig:   common,
-		ConfigState:    config,
+		InstanceConfiguration: ic,
+		ConfigState:           state,
 	}
 }
 

--- a/internal/resources/planner_test.go
+++ b/internal/resources/planner_test.go
@@ -32,72 +32,77 @@ func TestPlannerDNSRegister(t *testing.T) {
 
 	// no dns register specified
 	planner = newSharePlanner(
-		&sambaoperatorv1alpha1.SmbShare{},
-		&sambaoperatorv1alpha1.SmbSecurityConfig{
-			Spec: sambaoperatorv1alpha1.SmbSecurityConfigSpec{
-				Mode: "active-directory",
-			}},
-		&sambaoperatorv1alpha1.SmbCommonConfig{},
+		InstanceConfiguration{
+			SecurityConfig: &sambaoperatorv1alpha1.SmbSecurityConfig{
+				Spec: sambaoperatorv1alpha1.SmbSecurityConfigSpec{
+					Mode: "active-directory",
+				},
+			},
+		},
 		&smbcc.SambaContainerConfig{})
 	d = planner.dnsRegister()
 	assert.Equal(t, dnsRegisterNever, d)
 
 	// external-ip
 	planner = newSharePlanner(
-		&sambaoperatorv1alpha1.SmbShare{},
-		&sambaoperatorv1alpha1.SmbSecurityConfig{
-			Spec: sambaoperatorv1alpha1.SmbSecurityConfigSpec{
-				Mode: "active-directory",
-				DNS: &sambaoperatorv1alpha1.SmbSecurityDNSSpec{
-					Register: "external-ip",
+		InstanceConfiguration{
+			SecurityConfig: &sambaoperatorv1alpha1.SmbSecurityConfig{
+				Spec: sambaoperatorv1alpha1.SmbSecurityConfigSpec{
+					Mode: "active-directory",
+					DNS: &sambaoperatorv1alpha1.SmbSecurityDNSSpec{
+						Register: "external-ip",
+					},
 				},
-			}},
-		&sambaoperatorv1alpha1.SmbCommonConfig{},
+			},
+		},
 		&smbcc.SambaContainerConfig{})
 	d = planner.dnsRegister()
 	assert.Equal(t, dnsRegisterExternalIP, d)
 
 	// cluster-ip
 	planner = newSharePlanner(
-		&sambaoperatorv1alpha1.SmbShare{},
-		&sambaoperatorv1alpha1.SmbSecurityConfig{
-			Spec: sambaoperatorv1alpha1.SmbSecurityConfigSpec{
-				Mode: "active-directory",
-				DNS: &sambaoperatorv1alpha1.SmbSecurityDNSSpec{
-					Register: "cluster-ip",
+		InstanceConfiguration{
+			SecurityConfig: &sambaoperatorv1alpha1.SmbSecurityConfig{
+				Spec: sambaoperatorv1alpha1.SmbSecurityConfigSpec{
+					Mode: "active-directory",
+					DNS: &sambaoperatorv1alpha1.SmbSecurityDNSSpec{
+						Register: "cluster-ip",
+					},
 				},
-			}},
-		&sambaoperatorv1alpha1.SmbCommonConfig{},
+			},
+		},
 		&smbcc.SambaContainerConfig{})
 	d = planner.dnsRegister()
 	assert.Equal(t, dnsRegisterClusterIP, d)
 
 	// invalid string for register
 	planner = newSharePlanner(
-		&sambaoperatorv1alpha1.SmbShare{},
-		&sambaoperatorv1alpha1.SmbSecurityConfig{
-			Spec: sambaoperatorv1alpha1.SmbSecurityConfigSpec{
-				Mode: "active-directory",
-				DNS: &sambaoperatorv1alpha1.SmbSecurityDNSSpec{
-					Register: "junk",
+		InstanceConfiguration{
+			SecurityConfig: &sambaoperatorv1alpha1.SmbSecurityConfig{
+				Spec: sambaoperatorv1alpha1.SmbSecurityConfigSpec{
+					Mode: "active-directory",
+					DNS: &sambaoperatorv1alpha1.SmbSecurityDNSSpec{
+						Register: "junk",
+					},
 				},
-			}},
-		&sambaoperatorv1alpha1.SmbCommonConfig{},
+			},
+		},
 		&smbcc.SambaContainerConfig{})
 	d = planner.dnsRegister()
 	assert.Equal(t, dnsRegisterNever, d)
 
 	// not AD. ignore specified value
 	planner = newSharePlanner(
-		&sambaoperatorv1alpha1.SmbShare{},
-		&sambaoperatorv1alpha1.SmbSecurityConfig{
-			Spec: sambaoperatorv1alpha1.SmbSecurityConfigSpec{
-				Mode: "user",
-				DNS: &sambaoperatorv1alpha1.SmbSecurityDNSSpec{
-					Register: "cluster-ip",
+		InstanceConfiguration{
+			SecurityConfig: &sambaoperatorv1alpha1.SmbSecurityConfig{
+				Spec: sambaoperatorv1alpha1.SmbSecurityConfigSpec{
+					Mode: "user",
+					DNS: &sambaoperatorv1alpha1.SmbSecurityDNSSpec{
+						Register: "cluster-ip",
+					},
 				},
-			}},
-		&sambaoperatorv1alpha1.SmbCommonConfig{},
+			},
+		},
 		&smbcc.SambaContainerConfig{})
 	d = planner.dnsRegister()
 	assert.Equal(t, dnsRegisterNever, d)
@@ -111,15 +116,16 @@ func TestPlannerDNSRegisterArgs(t *testing.T) {
 
 	// external-ip
 	planner = newSharePlanner(
-		&sambaoperatorv1alpha1.SmbShare{},
-		&sambaoperatorv1alpha1.SmbSecurityConfig{
-			Spec: sambaoperatorv1alpha1.SmbSecurityConfigSpec{
-				Mode: "active-directory",
-				DNS: &sambaoperatorv1alpha1.SmbSecurityDNSSpec{
-					Register: "external-ip",
+		InstanceConfiguration{
+			SecurityConfig: &sambaoperatorv1alpha1.SmbSecurityConfig{
+				Spec: sambaoperatorv1alpha1.SmbSecurityConfigSpec{
+					Mode: "active-directory",
+					DNS: &sambaoperatorv1alpha1.SmbSecurityDNSSpec{
+						Register: "external-ip",
+					},
 				},
-			}},
-		&sambaoperatorv1alpha1.SmbCommonConfig{},
+			},
+		},
 		&smbcc.SambaContainerConfig{})
 	v = planner.dnsRegisterArgs()
 	assert.Equal(t,
@@ -128,15 +134,16 @@ func TestPlannerDNSRegisterArgs(t *testing.T) {
 
 	// cluster-ip
 	planner = newSharePlanner(
-		&sambaoperatorv1alpha1.SmbShare{},
-		&sambaoperatorv1alpha1.SmbSecurityConfig{
-			Spec: sambaoperatorv1alpha1.SmbSecurityConfigSpec{
-				Mode: "active-directory",
-				DNS: &sambaoperatorv1alpha1.SmbSecurityDNSSpec{
-					Register: "cluster-ip",
+		InstanceConfiguration{
+			SecurityConfig: &sambaoperatorv1alpha1.SmbSecurityConfig{
+				Spec: sambaoperatorv1alpha1.SmbSecurityConfigSpec{
+					Mode: "active-directory",
+					DNS: &sambaoperatorv1alpha1.SmbSecurityDNSSpec{
+						Register: "cluster-ip",
+					},
 				},
-			}},
-		&sambaoperatorv1alpha1.SmbCommonConfig{},
+			},
+		},
 		&smbcc.SambaContainerConfig{})
 	v = planner.dnsRegisterArgs()
 	assert.Equal(t,

--- a/internal/resources/pods.go
+++ b/internal/resources/pods.go
@@ -388,7 +388,7 @@ func svcWatchVolumeAndMount(dir string) (
 }
 
 func defaultPodEnv(planner *sharePlanner) []corev1.EnvVar {
-	return []corev1.EnvVar{
+	env := []corev1.EnvVar{
 		{
 			Name:  "SAMBA_CONTAINER_ID",
 			Value: string(planner.instanceID()),
@@ -398,6 +398,16 @@ func defaultPodEnv(planner *sharePlanner) []corev1.EnvVar {
 			Value: planner.containerConfigPath(),
 		},
 	}
+	// In the future we may want per-container debug levels. The
+	// infrastructure could support that. For the moment we simply have one
+	// debug level for all samba containers in the pod.
+	if lvl := planner.sambaContainerDebugLevel(); lvl != "" {
+		env = append(env, corev1.EnvVar{
+			Name:  "SAMBA_DEBUG_LEVEL",
+			Value: lvl,
+		})
+	}
+	return env
 }
 
 type joinSources struct {

--- a/internal/resources/smbshare.go
+++ b/internal/resources/smbshare.go
@@ -365,7 +365,14 @@ func (m *SmbShareManager) updateConfiguration(
 	}
 
 	// extract config from map
-	planner := newSharePlanner(s, security, common, cc)
+	planner := newSharePlanner(
+		InstanceConfiguration{
+			SmbShare:       s,
+			SecurityConfig: security,
+			CommonConfig:   common,
+			GlobalConfig:   m.cfg,
+		},
+		cc)
 	var changed bool
 	if isDeleting {
 		changed, err = planner.prune()


### PR DESCRIPTION
Add a samba-debug-level conf var / SAMBA_OP_SAMBA_DEBUG_LEVEL environment variable that can be used to enable debugging in samba components in the deployed pods.

Included update to developer doc.