### PR TITLE
docs: link youtube video to the presentations page

### DIFF
--- a/docs/presentations/README.md
+++ b/docs/presentations/README.md
@@ -17,5 +17,5 @@ first prototype of the samba-operator at the annual sambaXP conference in May 20
 The Next Phase" at the virtual sambaXP 2021.
 
 * [Slides](<./samba in kubernetes - sambaXP 2021.pdf>)
-* Recording - pending
+* [Recording (on youtube)](https://www.youtube.com/watch?v=mG-Jxaf8_gw)
 


### PR DESCRIPTION
We forgot to update this page after the sambaXP youtube channel got
updated with our presentation.

Signed-off-by: John Mulligan <jmulligan@redhat.com>