### PR TITLE
test utils: use more proper kube config loading for tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -128,7 +128,7 @@ jobs:
     - name: configure kustomize
       run: make set-image
     - name: run tests
-      run: KUBECONFIG=~/.kube/config ./tests/test.sh
+      run: ./tests/test.sh
 
   # push the container to quay.io - only for pushes, not PRs
   push:

--- a/tests/utils/kube/client.go
+++ b/tests/utils/kube/client.go
@@ -3,7 +3,6 @@ package kube
 import (
 	"context"
 	"errors"
-	"os"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -56,14 +55,17 @@ func (tc *TestClient) GetPodByLabel(
 
 // NewTestClient return a new kube util test client.
 func NewTestClient(kubeconfig string) *TestClient {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	if kubeconfig != "" {
+		loadingRules.ExplicitPath = kubeconfig
+	}
+	kcc := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		loadingRules, &clientcmd.ConfigOverrides{})
 	// TODO: add (or just verify) ability to also run _inside_ k8s
 	// rather than on some external node
 	tc := &TestClient{}
-	if kubeconfig == "" {
-		kubeconfig = os.Getenv("KUBECONFIG")
-	}
 	var err error
-	tc.cfg, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
+	tc.cfg, err = kcc.ClientConfig()
 	if err != nil {
 		panic(err)
 	}

--- a/tests/utils/smbclient/smbclient.go
+++ b/tests/utils/smbclient/smbclient.go
@@ -51,16 +51,18 @@ type kubectlSmbClientCli struct {
 }
 
 func (ksc *kubectlSmbClientCli) kubectlExecArgs() []string {
-	cmd := []string{
-		"kubectl",
-		fmt.Sprintf("--kubeconfig=%s", ksc.kubeconfig),
+	cmd := []string{"kubectl"}
+	if ksc.kubeconfig != "" {
+		cmd = append(cmd, fmt.Sprintf("--kubeconfig=%s", ksc.kubeconfig))
+	}
+	cmd = append(cmd,
 		"exec",
 		"--namespace",
 		ksc.namespace,
 		"-it",
 		ksc.pod,
 		"--",
-	}
+	)
 	return cmd
 }
 
@@ -145,10 +147,7 @@ func MustPodClient(namespace, pod string) SmbClient {
 	// very minute I'd rather do this than build a lot more comprehensive
 	// configuration for the test utilities.
 	kc := os.Getenv("KUBECONFIG")
-	if kc == "" {
-		panic(fmt.Errorf("KUBECONFIG not specified"))
-	}
-	if kc == "" {
+	if pod == "" {
 		panic(fmt.Errorf("pod is unset"))
 	}
 	return &kubectlSmbClientCli{


### PR DESCRIPTION
Fixes: #54 

Based on reading the docs at https://pkg.go.dev/k8s.io/client-go@v0.21.2/tools/clientcmd#pkg-overview