### PR TITLE
Various small improvements & accompanying revive rules

### DIFF
--- a/.revive.toml
+++ b/.revive.toml
@@ -38,6 +38,17 @@ warningCode = 0
 [rule.constant-logical-expr]
 [rule.unnecessary-stmt]
 [rule.unused-receiver]
+[rule.get-return]
+[rule.flag-parameter]
+[rule.confusing-results]
+[rule.confusing-naming]
+[rule.modifies-parameter]
+[rule.modifies-value-receiver]
+[rule.import-shadowing]
+[rule.range-val-in-closure]
+[rule.waitgroup-by-value]
+[rule.call-to-gc]
+[rule.duplicated-imports]
 
 [rule.argument-limit]
   arguments = [7]
@@ -47,3 +58,13 @@ warningCode = 0
 [rule.unhandled-error]
   # functions to ignore unhandled errors on
   arguments = ["fmt.Printf", "fmt.Println"]
+
+# kubebuilder's (apparently bogus!) use of ,inline all over the place
+# breaks this rule. So while ideally nice to have I'd rather err on the
+# side of k8s tooling. Even if it is a cargo cult :-P
+#[rule.struct-tag]
+
+[rule.line-length-limit]
+  # I'd ideally prefer 80 but some go idoms make lines a bit longer and
+  # not everyone probably loves to line break as much as me :-)
+  arguments =[98]

--- a/.revive.toml
+++ b/.revive.toml
@@ -17,8 +17,8 @@ warningCode = 0
 [rule.exported]
 [rule.if-return]
 [rule.increment-decrement]
-# TODO: make this rule live once code is fixed up (other PR)
-#[rule.var-naming]
+[rule.var-naming]
+  arguments = [["UID", "GID"]]
 [rule.var-declaration]
 [rule.package-comments]
 [rule.range]

--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1alpha1 contains API Schema definitions for the samba-operator v1alpha1 API group
+// Package v1alpha1 contains API Schema definitions for the samba-operator
+// v1alpha1 API group
 // +kubebuilder:object:generate=true
 // +groupName=samba-operator.samba.org
 package v1alpha1
@@ -26,7 +27,10 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "samba-operator.samba.org", Version: "v1alpha1"}
+	GroupVersion = schema.GroupVersion{
+		Group:   "samba-operator.samba.org",
+		Version: "v1alpha1",
+	}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/api/v1alpha1/smbcommonconfig_types.go
+++ b/api/v1alpha1/smbcommonconfig_types.go
@@ -21,7 +21,8 @@ import (
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
-// NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
+// NOTE: json tags are required.  Any new fields you add must have json tags
+// for the fields to be serialized.
 
 // SmbCommonConfigSpec values act as a template for properties of the services
 // that will host shares.

--- a/api/v1alpha1/smbsecurityconfig_types.go
+++ b/api/v1alpha1/smbsecurityconfig_types.go
@@ -21,7 +21,8 @@ import (
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
-// NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
+// NOTE: json tags are required.  Any new fields you add must have json tags
+// for the fields to be serialized.
 
 // SmbSecurityConfigSpec defines the desired state of SmbSecurityConfig
 type SmbSecurityConfigSpec struct {

--- a/api/v1alpha1/smbshare_types.go
+++ b/api/v1alpha1/smbshare_types.go
@@ -23,7 +23,8 @@ import (
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // Important: Run "make" to regenerate code after modifying this file
-// NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
+// NOTE: json tags are required.  Any new fields you add must have json tags
+// for the fields to be serialized.
 
 // SmbShareSpec defines the desired state of SmbShare
 type SmbShareSpec struct {

--- a/controllers/smbcommonconfig_controller.go
+++ b/controllers/smbcommonconfig_controller.go
@@ -34,8 +34,12 @@ type SmbCommonConfigReconciler struct {
 	Scheme *runtime.Scheme
 }
 
+//revive:disable kubebuilder directives
+
 // +kubebuilder:rbac:groups=samba-operator.samba.org,resources=smbcommonconfigs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=samba-operator.samba.org,resources=smbcommonconfigs/status,verbs=get;update;patch
+
+//revive:enable
 
 // Reconcile SmbCommonConfig resources.
 func (r *SmbCommonConfigReconciler) Reconcile(req ctrl.Request) (

--- a/controllers/smbcommonconfig_controller.go
+++ b/controllers/smbcommonconfig_controller.go
@@ -38,7 +38,9 @@ type SmbCommonConfigReconciler struct {
 // +kubebuilder:rbac:groups=samba-operator.samba.org,resources=smbcommonconfigs/status,verbs=get;update;patch
 
 // Reconcile SmbCommonConfig resources.
-func (r *SmbCommonConfigReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
+func (r *SmbCommonConfigReconciler) Reconcile(req ctrl.Request) (
+	ctrl.Result, error) {
+	// ---
 	_ = context.Background()
 	_ = r.Log.WithValues("smbcommonconfig", req.NamespacedName)
 

--- a/controllers/smbsecurityconfig_controller.go
+++ b/controllers/smbsecurityconfig_controller.go
@@ -34,8 +34,12 @@ type SmbSecurityConfigReconciler struct {
 	Scheme *runtime.Scheme
 }
 
+//revive:disable kubebuilder directives
+
 // +kubebuilder:rbac:groups=samba-operator.samba.org,resources=smbsecurityconfigs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=samba-operator.samba.org,resources=smbsecurityconfigs/status,verbs=get;update;patch
+
+//revive:enable
 
 // Reconcile the SmbSecurityConfig resource.
 func (r *SmbSecurityConfigReconciler) Reconcile(req ctrl.Request) (

--- a/controllers/smbsecurityconfig_controller.go
+++ b/controllers/smbsecurityconfig_controller.go
@@ -38,7 +38,9 @@ type SmbSecurityConfigReconciler struct {
 // +kubebuilder:rbac:groups=samba-operator.samba.org,resources=smbsecurityconfigs/status,verbs=get;update;patch
 
 // Reconcile the SmbSecurityConfig resource.
-func (r *SmbSecurityConfigReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
+func (r *SmbSecurityConfigReconciler) Reconcile(req ctrl.Request) (
+	ctrl.Result, error) {
+	// ---
 	_ = context.Background()
 	_ = r.Log.WithValues("smbsecurityconfig", req.NamespacedName)
 

--- a/controllers/smbshare_controller.go
+++ b/controllers/smbshare_controller.go
@@ -39,6 +39,8 @@ type SmbShareReconciler struct {
 	recorder record.EventRecorder
 }
 
+//revive:disable kubebuilder directives
+
 // +kubebuilder:rbac:groups=samba-operator.samba.org,resources=smbshares,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=samba-operator.samba.org,resources=smbshares/finalizers,verbs=get;update;patch
 // +kubebuilder:rbac:groups=samba-operator.samba.org,resources=smbshares/status,verbs=get;update;patch
@@ -48,6 +50,8 @@ type SmbShareReconciler struct {
 // +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=events,verbs=create
+
+//revive:enable
 
 // Reconcile SmbShare resources.
 func (r *SmbShareReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -35,7 +35,8 @@ func (oc *OperatorConfig) Validate() error {
 	// Ensure that WorkingNamespace is set. We don't default it to anything.
 	// It must be passed in, typically by the operator's own pod spec.
 	if oc.WorkingNamespace == "" {
-		return fmt.Errorf("WorkingNamespace value [%s] invalid", oc.WorkingNamespace)
+		return fmt.Errorf(
+			"WorkingNamespace value [%s] invalid", oc.WorkingNamespace)
 	}
 	return nil
 }
@@ -49,10 +50,14 @@ type Source struct {
 // NewSource creates a new Source based on default configuration values.
 func NewSource() *Source {
 	v := viper.New()
-	v.SetDefault("smbd-container-image", "quay.io/samba.org/samba-server:latest")
+	v.SetDefault(
+		"smbd-container-image",
+		"quay.io/samba.org/samba-server:latest")
 	v.SetDefault("smbd-container-name", "samba")
 	v.SetDefault("working-namespace", "")
-	v.SetDefault("svc-watch-container-image", "quay.io/samba.org/svcwatch:latest")
+	v.SetDefault(
+		"svc-watch-container-image",
+		"quay.io/samba.org/svcwatch:latest")
 	v.SetDefault("samba-debug-level", "")
 	return &Source{v: v}
 }

--- a/internal/resources/configmap.go
+++ b/internal/resources/configmap.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	rtclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/samba-in-kubernetes/samba-operator/internal/smbcc"
 )
@@ -36,7 +36,7 @@ const (
 )
 
 func getConfigMap(
-	ctx context.Context, client client.Client, ns string) (
+	ctx context.Context, client rtclient.Client, ns string) (
 	*corev1.ConfigMap, error) {
 	// fetch the existing config, if available
 	cm := &corev1.ConfigMap{}
@@ -51,7 +51,7 @@ func getConfigMap(
 }
 
 func getOrCreateConfigMap(
-	ctx context.Context, client client.Client, ns string) (
+	ctx context.Context, client rtclient.Client, ns string) (
 	*corev1.ConfigMap, bool, error) {
 	// fetch the existing config, if available
 	cm, err := getConfigMap(ctx, client, ns)

--- a/internal/resources/configmap.go
+++ b/internal/resources/configmap.go
@@ -92,7 +92,9 @@ func newDefaultConfigMap(name, ns string) (*corev1.ConfigMap, error) {
 	return cm, nil
 }
 
-func getContainerConfig(cm *corev1.ConfigMap) (*smbcc.SambaContainerConfig, error) {
+func getContainerConfig(
+	cm *corev1.ConfigMap) (*smbcc.SambaContainerConfig, error) {
+	// ---
 	cc := smbcc.New()
 	jstr, found := cm.Data[ConfigJSONKey]
 	if !found {
@@ -104,7 +106,9 @@ func getContainerConfig(cm *corev1.ConfigMap) (*smbcc.SambaContainerConfig, erro
 	return cc, nil
 }
 
-func setContainerConfig(cm *corev1.ConfigMap, cc *smbcc.SambaContainerConfig) error {
+func setContainerConfig(
+	cm *corev1.ConfigMap, cc *smbcc.SambaContainerConfig) error {
+	// ---
 	jb, err := json.MarshalIndent(cc, "", "  ")
 	if err != nil {
 		return err

--- a/internal/resources/planner.go
+++ b/internal/resources/planner.go
@@ -158,20 +158,20 @@ func (sp *sharePlanner) workgroup() string {
 	return parts[0]
 }
 
-func (*sharePlanner) joinJsonSuffix(index int) string {
+func (*sharePlanner) joinJSONSuffix(index int) string {
 	return fmt.Sprintf("-%d", index)
 }
 
-func (*sharePlanner) joinJsonSourceDir(index int) string {
+func (*sharePlanner) joinJSONSourceDir(index int) string {
 	return fmt.Sprintf("/var/tmp/join/%d", index)
 }
 
-func (*sharePlanner) joinJsonFileName() string {
+func (*sharePlanner) joinJSONFileName() string {
 	return "join.json"
 }
 
-func (sp *sharePlanner) joinJsonSourcePath(index int) string {
-	return path.Join(sp.joinJsonSourceDir(index), sp.joinJsonFileName())
+func (sp *sharePlanner) joinJSONSourcePath(index int) string {
+	return path.Join(sp.joinJSONSourceDir(index), sp.joinJSONFileName())
 }
 
 func (*sharePlanner) joinEnvPaths(p []string) string {

--- a/internal/resources/planner_test.go
+++ b/internal/resources/planner_test.go
@@ -147,6 +147,11 @@ func TestPlannerDNSRegisterArgs(t *testing.T) {
 		&smbcc.SambaContainerConfig{})
 	v = planner.dnsRegisterArgs()
 	assert.Equal(t,
-		[]string{"dns-register", "--watch", "--target=internal", "/var/lib/svcwatch/status.json"},
+		[]string{
+			"dns-register",
+			"--watch",
+			"--target=internal",
+			"/var/lib/svcwatch/status.json",
+		},
 		v)
 }

--- a/internal/resources/pods.go
+++ b/internal/resources/pods.go
@@ -29,7 +29,7 @@ const (
 	wbSocketsVolName  = "samba-wb-sockets-dir"
 	stateVolName      = "samba-state-dir"
 	osRunVolName      = "run"
-	joinJsonVolName   = "join-data"
+	joinJSONVolName   = "join-data"
 )
 
 func buildPodSpec(planner *sharePlanner, cfg *conf.OperatorConfig, pvcName string) corev1.PodSpec {
@@ -342,10 +342,10 @@ func wbSocketsVolumeAndMount(planner *sharePlanner) (
 	return volume, mount
 }
 
-func joinJsonFileVolumeAndMount(planner *sharePlanner, index int) (
+func joinJSONFileVolumeAndMount(planner *sharePlanner, index int) (
 	corev1.Volume, corev1.VolumeMount) {
 	// volume
-	vname := joinJsonVolName + planner.joinJsonSuffix(index)
+	vname := joinJSONVolName + planner.joinJSONSuffix(index)
 	j := planner.SecurityConfig.Spec.JoinSources[index]
 	volume := corev1.Volume{
 		Name: vname,
@@ -354,14 +354,14 @@ func joinJsonFileVolumeAndMount(planner *sharePlanner, index int) (
 				SecretName: j.UserJoin.Secret,
 				Items: []corev1.KeyToPath{{
 					Key:  j.UserJoin.Key,
-					Path: planner.joinJsonFileName(),
+					Path: planner.joinJSONFileName(),
 				}},
 			},
 		},
 	}
 	// mount
 	mount := corev1.VolumeMount{
-		MountPath: planner.joinJsonSourceDir(index),
+		MountPath: planner.joinJSONSourceDir(index),
 		Name:      vname,
 	}
 	return volume, mount
@@ -424,10 +424,10 @@ func getJoinSources(planner *sharePlanner) joinSources {
 	}
 	for i, js := range planner.SecurityConfig.Spec.JoinSources {
 		if js.UserJoin != nil {
-			v, m := joinJsonFileVolumeAndMount(planner, i)
+			v, m := joinJSONFileVolumeAndMount(planner, i)
 			src.volumes = append(src.volumes, v)
 			src.mounts = append(src.mounts, m)
-			src.paths = append(src.paths, planner.joinJsonSourcePath(i))
+			src.paths = append(src.paths, planner.joinJSONSourcePath(i))
 		}
 	}
 	return src

--- a/internal/resources/pods.go
+++ b/internal/resources/pods.go
@@ -32,14 +32,22 @@ const (
 	joinJSONVolName   = "join-data"
 )
 
-func buildPodSpec(planner *sharePlanner, cfg *conf.OperatorConfig, pvcName string) corev1.PodSpec {
+func buildPodSpec(
+	planner *sharePlanner,
+	cfg *conf.OperatorConfig,
+	pvcName string) corev1.PodSpec {
+	// ---
 	if planner.securityMode() == adMode {
 		return buildADPodSpec(planner, cfg, pvcName)
 	}
 	return buildUserPodSpec(planner, cfg, pvcName)
 }
 
-func buildADPodSpec(planner *sharePlanner, cfg *conf.OperatorConfig, pvcName string) corev1.PodSpec {
+func buildADPodSpec(
+	planner *sharePlanner,
+	cfg *conf.OperatorConfig,
+	pvcName string) corev1.PodSpec {
+	// ---
 	volumes := []corev1.Volume{}
 	mounts := []corev1.VolumeMount{}
 
@@ -175,7 +183,11 @@ func buildADPodSpec(planner *sharePlanner, cfg *conf.OperatorConfig, pvcName str
 	return podSpec
 }
 
-func buildUserPodSpec(planner *sharePlanner, cfg *conf.OperatorConfig, pvcName string) corev1.PodSpec {
+func buildUserPodSpec(
+	planner *sharePlanner,
+	cfg *conf.OperatorConfig,
+	pvcName string) corev1.PodSpec {
+	// ---
 	volumes := []corev1.Volume{}
 	mounts := []corev1.VolumeMount{}
 

--- a/internal/resources/smbshare.go
+++ b/internal/resources/smbshare.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	rtclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	sambaoperatorv1alpha1 "github.com/samba-in-kubernetes/samba-operator/api/v1alpha1"
@@ -36,7 +36,7 @@ const shareFinalizer = "samba-operator.samba.org/shareFinalizer"
 
 // SmbShareManager is used to manage SmbShare resources.
 type SmbShareManager struct {
-	client   client.Client
+	client   rtclient.Client
 	scheme   *runtime.Scheme
 	recorder record.EventRecorder
 	logger   Logger
@@ -45,7 +45,7 @@ type SmbShareManager struct {
 
 // NewSmbShareManager creates a SmbShareManager.
 func NewSmbShareManager(
-	client client.Client, scheme *runtime.Scheme,
+	client rtclient.Client, scheme *runtime.Scheme,
 	recorder record.EventRecorder, logger Logger) *SmbShareManager {
 	return &SmbShareManager{
 		client:   client,

--- a/main.go
+++ b/main.go
@@ -54,10 +54,18 @@ func main() {
 	confSource := conf.NewSource()
 	var metricsAddr string
 	var enableLeaderElection bool
-	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
-	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
+	flag.StringVar(
+		&metricsAddr,
+		"metrics-addr",
+		":8080",
+		"The address the metric endpoint binds to.")
+	flag.BoolVar(
+		&enableLeaderElection,
+		"enable-leader-election",
+		false,
 		"Enable leader election for controller manager. "+
-			"Enabling this will ensure there is only one active controller manager.")
+			"Enabling this will ensure there is only one active "+
+			"controller manager.")
 	flag.CommandLine.AddFlagSet(confSource.Flags())
 	flag.Parse()
 
@@ -89,7 +97,10 @@ func main() {
 		Log:    ctrl.Log.WithName("controllers").WithName("SmbShare"),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "SmbShare")
+		setupLog.Error(
+			err,
+			"unable to create controller",
+			"controller", "SmbShare")
 		os.Exit(1)
 	}
 	if err = (&controllers.SmbSecurityConfigReconciler{
@@ -97,7 +108,10 @@ func main() {
 		Log:    ctrl.Log.WithName("controllers").WithName("SmbSecurityConfig"),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "SmbSecurityConfig")
+		setupLog.Error(
+			err,
+			"unable to create controller",
+			"controller", "SmbSecurityConfig")
 		os.Exit(1)
 	}
 	if err = (&controllers.SmbCommonConfigReconciler{
@@ -105,7 +119,10 @@ func main() {
 		Log:    ctrl.Log.WithName("controllers").WithName("SmbCommonConfig"),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "SmbCommonConfig")
+		setupLog.Error(
+			err,
+			"unable to create controller",
+			"controller", "SmbCommonConfig")
 		os.Exit(1)
 	}
 	// +kubebuilder:scaffold:builder

--- a/tests/utils/kube/dynamic.go
+++ b/tests/utils/kube/dynamic.go
@@ -134,7 +134,9 @@ func (tc *TestClient) DeleteResourceMatchingFile(
 	return nil
 }
 
-func getUnstructuredObjects(src InputSource) (objects []*unstructured.Unstructured, err error) {
+func getUnstructuredObjects(src InputSource) (
+	objects []*unstructured.Unstructured, err error) {
+	// ---
 	r, err := src.Open()
 	if err != nil {
 		return nil, err
@@ -254,7 +256,10 @@ func chooseNamespace(ns ...string) string {
 	return n
 }
 
-func useNamespace(nri dynamic.NamespaceableResourceInterface, mapping *meta.RESTMapping, namespace string) dynamic.ResourceInterface {
+func useNamespace(
+	nri dynamic.NamespaceableResourceInterface, mapping *meta.RESTMapping,
+	namespace string) dynamic.ResourceInterface {
+	// ---
 	if mapping.Scope.Name() == meta.RESTScopeNameNamespace {
 		return nri.Namespace(namespace)
 	}

--- a/tests/utils/smbclient/smbclient.go
+++ b/tests/utils/smbclient/smbclient.go
@@ -95,14 +95,16 @@ func (ksc *kubectlSmbClientCli) Command(
 		ctx, auth, []string{share.String(), "-c", cstring})
 	oe, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("failed to execute smbclient command: %v: %w [stdio: %s]",
+		return fmt.Errorf(
+			"failed to execute smbclient command: %v: %w [stdio: %s]",
 			cmd.Args, err, string(oe))
 	}
 	return nil
 }
 
 func (ksc *kubectlSmbClientCli) CommandOutput(
-	ctx context.Context, share Share, auth Auth, shareCmd []string) ([]byte, error) {
+	ctx context.Context, share Share, auth Auth, shareCmd []string) (
+	[]byte, error) {
 	// ---
 	cstring := strings.Join(shareCmd, "; ")
 	cmd := ksc.smbclientCmd(


### PR DESCRIPTION
Revive has a lot more rules than we were using. Unlike another project I am involved with, this one is a lot more "typical Go" and young and so we can afford to enable more rules.

The changes clean up some of the issues found, including some formatting stuff.
Finally I commit the new rules.