### PR TITLE
tests: use k8s api for executing smbclient commands

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -93,6 +93,7 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153 h1:yUdfgN0XgIJw7foRItutHYUIhlcKzcSf5vDpdhQAKTc=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
@@ -285,6 +286,7 @@ github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0Qu
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
+github.com/moby/spdystream v0.2.0 h1:cjW1zVyyoiM0T7b6UoySUFqzXMoqRckQtXwGPiBhOM8=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/moby/term v0.0.0-20210610120745-9d4ed1856297/go.mod h1:vgPCkQMyxTZ7IDy8SXRufE172gr8+K/JE/7hHFxHW3A=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/tests/integration/share_access_test.go
+++ b/tests/integration/share_access_test.go
@@ -64,7 +64,8 @@ func (s *ShareAccessSuite) SetupSuite() {
 
 // TestLogin verifies that users can log into the share.
 func (s *ShareAccessSuite) TestLogin() {
-	smbclient := smbclient.MustPodClient(testNamespace, s.clientPod)
+	tc := kube.NewTestClient("")
+	smbclient := smbclient.MustPodExec(tc, testNamespace, s.clientPod, "")
 	err := smbclient.CacheFlush(context.TODO())
 	s.Require().NoError(err)
 	for _, auth := range s.auths {
@@ -78,7 +79,8 @@ func (s *ShareAccessSuite) TestLogin() {
 }
 
 func (s *ShareAccessSuite) TestPutFile() {
-	smbclient := smbclient.MustPodClient(testNamespace, s.clientPod)
+	tc := kube.NewTestClient("")
+	smbclient := smbclient.MustPodExec(tc, testNamespace, s.clientPod, "")
 	err := smbclient.CacheFlush(context.TODO())
 	s.Require().NoError(err)
 	auth := s.auths[0]

--- a/tests/utils/kube/exec.go
+++ b/tests/utils/kube/exec.go
@@ -1,0 +1,141 @@
+package kube
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	corev1api "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/remotecommand"
+)
+
+const (
+	podsResourceName   = "pods"
+	execSubResource    = "exec"
+	containerParamName = "container"
+)
+
+// PodCommand identifies a pod and a container and a command to run.
+type PodCommand struct {
+	Command       []string
+	Namespace     string
+	PodName       string
+	ContainerName string
+}
+
+// BufferedCommandHandler uses byte buffers to save command output.
+type BufferedCommandHandler struct {
+	stdout *bytes.Buffer
+	stderr *bytes.Buffer
+}
+
+// NewBufferedCommandHandler returns a new BufferedCommandHandler.
+func NewBufferedCommandHandler() *BufferedCommandHandler {
+	b1 := make([]byte, 0, 2048)
+	b2 := make([]byte, 0, 2048)
+	return &BufferedCommandHandler{
+		stdout: bytes.NewBuffer(b1),
+		stderr: bytes.NewBuffer(b2),
+	}
+}
+
+// Stdout returns the stdout writer for this request.
+func (bpc *BufferedCommandHandler) Stdout() io.Writer {
+	return bpc.stdout
+}
+
+// Stderr returns the stderr writer for this request.
+func (bpc *BufferedCommandHandler) Stderr() io.Writer {
+	return bpc.stderr
+}
+
+// GetStdout returns the stdout data.
+func (bpc *BufferedCommandHandler) GetStdout() []byte {
+	return bpc.stdout.Bytes()
+}
+
+// GetStderr returns the stderr data.
+func (bpc *BufferedCommandHandler) GetStderr() []byte {
+	return bpc.stderr.Bytes()
+}
+
+// CommandHandler interfaces provide parameters for running a command on a pod.
+type CommandHandler interface {
+	Stdout() io.Writer
+	Stderr() io.Writer
+}
+
+// TestExec is used to execute CommandRequests.
+type TestExec struct {
+	tclient *TestClient
+}
+
+// NewTestExec returns a new TestExec pointer.
+func NewTestExec(tclient *TestClient) *TestExec {
+	return &TestExec{tclient}
+}
+
+// Call executes the requested command on the pod.
+func (te *TestExec) Call(pc PodCommand, ch CommandHandler) error {
+	execOpts := corev1api.PodExecOptions{
+		Stdin:     false,
+		Stdout:    true,
+		Stderr:    true,
+		TTY:       false,
+		Container: pc.ContainerName,
+		Command:   pc.Command,
+	}
+	streamOpts := remotecommand.StreamOptions{
+		Stdout: ch.Stdout(),
+		Stderr: ch.Stderr(),
+	}
+
+	// create the request that will be used to produce a url for spdy
+	req := te.tclient.Clientset().CoreV1().RESTClient().
+		Post().
+		Resource(podsResourceName).
+		Namespace(pc.Namespace).
+		Name(pc.PodName).
+		SubResource(execSubResource).
+		Param(containerParamName, pc.ContainerName).
+		VersionedParams(&execOpts, scheme.ParameterCodec)
+
+	exec, err := remotecommand.NewSPDYExecutor(
+		te.tclient.cfg,
+		http.MethodPost,
+		req.URL())
+	if err != nil {
+		return fmt.Errorf(
+			"failed to set up executor (pod:%s/%s container:%s): %w",
+			pc.Namespace,
+			pc.PodName,
+			pc.ContainerName,
+			err)
+	}
+	err = exec.Stream(streamOpts)
+	if err != nil {
+		return fmt.Errorf(
+			"failed executing command (pod:%s/%s container:%s): %w",
+			pc.Namespace,
+			pc.PodName,
+			pc.ContainerName,
+			err)
+	}
+	return nil
+}
+
+// ExitCode returns an non-successful exit code value for a given error, and a
+// boolean set to true if the exit code is based on the error itself.
+func ExitCode(err error) (int, bool) {
+	var xe interface {
+		error
+		ExitStatus() int
+	}
+	if ok := errors.As(err, &xe); ok {
+		return xe.ExitStatus(), ok
+	}
+	return 1, false
+}

--- a/tests/utils/smbclient/smbclient_test.go
+++ b/tests/utils/smbclient/smbclient_test.go
@@ -2,86 +2,259 @@ package smbclient
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/samba-in-kubernetes/samba-operator/tests/utils/kube"
 )
 
-func TestBaseArgs(t *testing.T) {
-	c := &kubectlSmbClientCli{
-		kubeconfig: "/tmp/my/kubeconfig",
-		pod:        "smbclient-pod",
-		namespace:  "foo",
-	}
+func TestCommandBuilders(t *testing.T) {
 	var cmd []string
-	cmd = c.baseArgs(Auth{"bob", "passw0rd"})
+	cmd = smbclientWithAuth(Auth{"bob", "passw0rd"})
 	assert.Equal(t,
 		[]string{
-			"kubectl",
-			"--kubeconfig=/tmp/my/kubeconfig",
-			"exec",
-			"--namespace",
-			"foo",
-			"-it",
-			"smbclient-pod",
-			"--",
 			"smbclient",
 			"-Ubob%passw0rd",
 		},
 		cmd)
-	cmd = c.baseArgs(Auth{"fred", ""})
+	cmd = smbclientWithAuth(Auth{"fred", ""})
 	assert.Equal(t,
 		[]string{
-			"kubectl",
-			"--kubeconfig=/tmp/my/kubeconfig",
-			"exec",
-			"--namespace",
-			"foo",
-			"-it",
-			"smbclient-pod",
-			"--",
 			"smbclient",
 			"-Ufred",
 		},
 		cmd)
+
+	cmd = addSmbClientShare(cmd, Share{Host("localhost"), "foo"})
+	assert.Equal(t,
+		[]string{
+			"smbclient",
+			"-Ufred",
+			"//localhost/foo",
+		},
+		cmd)
+
+	cmd = addSmbClientShareCommands(cmd, []string{"ls", "put cat.jpg"})
+	assert.Equal(t,
+		[]string{
+			"smbclient",
+			"-Ufred",
+			"//localhost/foo",
+			"-c",
+			"ls; put cat.jpg",
+		},
+		cmd)
 }
 
-func TestCmd(t *testing.T) {
-	ctx := context.TODO()
-	c := &kubectlSmbClientCli{
-		kubeconfig: "/tmp/my/kubeconfig",
-		pod:        "smbclient-pod",
-		namespace:  "foo",
-		prefix:     []string{"echo"},
-	}
-	share := Share{Host("localhost"), "Stuff"}
-	cmd := c.smbclientCmd(
-		ctx,
-		Auth{"bob", "passw0rd"},
-		[]string{share.String(), "-c", "ls"})
-	assert.NotNil(t, cmd)
+func TestCommandError(t *testing.T) {
+	var ce CommandError
+	t.Run("minimal", func(t *testing.T) {
+		ce = CommandError{
+			Desc: "foobar",
+			Err:  fmt.Errorf("baz"),
+		}
+		assert.Equal(t,
+			"foobar: baz [exit: 0; stdout: ; stderr: ]",
+			ce.Error())
+	})
+	t.Run("stdout", func(t *testing.T) {
+		ce = CommandError{
+			Desc:   "foobar",
+			Err:    fmt.Errorf("baz"),
+			Output: "quux blat",
+		}
+		assert.Equal(t,
+			"foobar: baz [exit: 0; stdout: quux blat; stderr: ]",
+			ce.Error())
+	})
+	t.Run("stderr", func(t *testing.T) {
+		ce = CommandError{
+			Desc:      "foobar",
+			Err:       fmt.Errorf("baz"),
+			ErrOutput: "womble woo",
+		}
+		assert.Equal(t,
+			"foobar: baz [exit: 0; stdout: ; stderr: womble woo]",
+			ce.Error())
+	})
+	t.Run("everything", func(t *testing.T) {
+		ce = CommandError{
+			Desc:       "foobar",
+			Command:    []string{"smbclient", "-Usambauser%samba", "//localhost/foo"},
+			Err:        fmt.Errorf("baz"),
+			Output:     "quux blat",
+			ErrOutput:  "womble woo",
+			ExitStatus: 2,
+		}
+		assert.Equal(t,
+			"foobar: ['smbclient' '-Usambauser%samba' '//localhost/foo']:"+
+				" baz [exit: 2; stdout: quux blat; stderr: womble woo]",
+			ce.Error())
+	})
+	t.Run("unwrap", func(t *testing.T) {
+		e := fmt.Errorf("its me")
+		ce = CommandError{
+			Desc: "foobar",
+			Err:  e,
+		}
+		assert.Equal(t, e, ce.Unwrap())
+	})
 }
 
-func TestCommand(t *testing.T) {
+func TestPodExecList(t *testing.T) {
+	pe := &podExecSmbClientCli{}
 	ctx := context.TODO()
-	c := &kubectlSmbClientCli{
-		kubeconfig: "/tmp/my/kubeconfig",
-		pod:        "smbclient-pod",
-		namespace:  "foo",
-		prefix:     []string{"echo"},
-	}
-	err := c.Command(
+	_, err := pe.List(
 		ctx,
-		Share{Host("localhost"), "Stuff"},
+		Host("localhost"),
 		Auth{"bob", "passw0rd"},
-		[]string{"ls"})
-	assert.NoError(t, err)
-
-	c.prefix = []string{"/usr/bin/false"}
-	err = c.Command(
-		ctx,
-		Share{Host("localhost"), "Stuff"},
-		Auth{"bob", "passw0rd"},
-		[]string{"ls"})
+	)
 	assert.Error(t, err)
+}
+
+type phonyExecer struct {
+	err       error
+	output    string
+	errOutput string
+}
+
+func (p phonyExecer) Call(_ kube.PodCommand, h kube.CommandHandler) error {
+	_, _ = h.Stdout().Write([]byte(p.output))
+	_, _ = h.Stderr().Write([]byte(p.errOutput))
+	return p.err
+}
+
+func TestPodExecCommand(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		pe := &podExecSmbClientCli{
+			namespace: "default",
+			pod:       "smbclient",
+			container: "",
+			texec: phonyExecer{
+				err:       nil,
+				output:    "great",
+				errOutput: "",
+			}}
+		ctx := context.TODO()
+		err := pe.Command(
+			ctx,
+			Share{Host("localhost"), "Stuff"},
+			Auth{"bob", "passw0rd"},
+			[]string{"ls"},
+		)
+		assert.NoError(t, err)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		pe := &podExecSmbClientCli{
+			namespace: "default",
+			pod:       "smbclient",
+			container: "",
+			texec: phonyExecer{
+				err:       fmt.Errorf("kaboom"),
+				output:    "sorry",
+				errOutput: "I broke",
+			}}
+		ctx := context.TODO()
+		err := pe.Command(
+			ctx,
+			Share{Host("localhost"), "Stuff"},
+			Auth{"bob", "passw0rd"},
+			[]string{"ls"},
+		)
+		assert.Error(t, err)
+		assert.Equal(t,
+			`failed to execute smbclient command:`+
+				` ['smbclient' '-Ubob%passw0rd' '//localhost/Stuff' '-c' 'ls']:`+
+				` kaboom [exit: 1; stdout: sorry; stderr: I broke]`,
+			err.Error())
+	})
+}
+
+func TestPodExecCommandOutput(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		pe := &podExecSmbClientCli{
+			namespace: "default",
+			pod:       "smbclient",
+			container: "",
+			texec: phonyExecer{
+				err:       nil,
+				output:    "great",
+				errOutput: "",
+			}}
+		ctx := context.TODO()
+		o, err := pe.CommandOutput(
+			ctx,
+			Share{Host("localhost"), "Stuff"},
+			Auth{"bob", "passw0rd"},
+			[]string{"ls"},
+		)
+		assert.NoError(t, err)
+		assert.Equal(t, "great", string(o))
+	})
+
+	t.Run("error", func(t *testing.T) {
+		pe := &podExecSmbClientCli{
+			namespace: "default",
+			pod:       "smbclient",
+			container: "",
+			texec: phonyExecer{
+				err:       fmt.Errorf("kaboom"),
+				output:    "sorry",
+				errOutput: "I broke",
+			}}
+		ctx := context.TODO()
+		o, err := pe.CommandOutput(
+			ctx,
+			Share{Host("localhost"), "Stuff"},
+			Auth{"bob", "passw0rd"},
+			[]string{"ls"},
+		)
+		assert.Error(t, err)
+		assert.Equal(t,
+			`failed to execute smbclient command:`+
+				` ['smbclient' '-Ubob%passw0rd' '//localhost/Stuff' '-c' 'ls']:`+
+				` kaboom [exit: 1; stdout: sorry; stderr: I broke]`,
+			err.Error())
+		assert.Nil(t, o)
+	})
+}
+
+func TestPodExecCacheFlush(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		pe := &podExecSmbClientCli{
+			namespace: "default",
+			pod:       "smbclient",
+			container: "",
+			texec: phonyExecer{
+				err:       nil,
+				output:    "great",
+				errOutput: "",
+			}}
+		ctx := context.TODO()
+		err := pe.CacheFlush(ctx)
+		assert.NoError(t, err)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		pe := &podExecSmbClientCli{
+			namespace: "default",
+			pod:       "smbclient",
+			container: "",
+			texec: phonyExecer{
+				err:       fmt.Errorf("kaboom"),
+				output:    "sorry",
+				errOutput: "I broke",
+			}}
+		ctx := context.TODO()
+		err := pe.CacheFlush(ctx)
+		assert.Error(t, err)
+		assert.Equal(t,
+			`failed to flush cache:`+
+				` ['rm' '-f' '/var/lib/samba/lock/gencache.tdb']:`+
+				` kaboom [exit: 1; stdout: sorry; stderr: I broke]`,
+			err.Error())
+	})
 }


### PR DESCRIPTION
Previously, we were shelling out to `kubectl exec` to run smbclient commands on our smbclient test pod. These changes add a new api based TestExec type to the `test/utils/kube` package. Then it replaces the kubectl based version with a new version based on TestExec and its types.

This should be more effieicent as well as hopefully fix #93 because the old implementation was (ab)using KUBECONFIG in a way that broke on some setups.

fixes: #93 