### PR TITLE
workflows: force a version of k3s that should fix our ci issues

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,7 +113,7 @@ jobs:
     - name: Create k3d registry
       run: k3d registry create "${REG_BASE}" --port "${REG_PORT}"
     - name: Create k3d cluster
-      run: k3d cluster create --wait --registry-use "${REGISTRY}"
+      run: k3d cluster create --wait --image docker.io/rancher/k3s:v1.21.5-k3s1 --registry-use "${REGISTRY}"
     - name: Wait for cluster ready
       run: |
         while ! kubectl get serviceaccount default >/dev/null; do sleep 1; done


### PR DESCRIPTION
See: https://github.com/k3s-io/k3s/issues/3704

Figuring out what to actually put on the --image option was far harder
than it seems it should have been. :-\

Signed-off-by: John Mulligan <jmulligan@redhat.com>