### PR TITLE
Fix namespace behavior

### DIFF
--- a/internal/resources/smbshare.go
+++ b/internal/resources/smbshare.go
@@ -117,7 +117,7 @@ func (m *SmbShareManager) Update(
 		return Requeue
 	}
 
-	destNamespace := m.cfg.WorkingNamespace
+	destNamespace := instance.Namespace
 	cm, created, err := getOrCreateConfigMap(ctx, m.client, destNamespace)
 	if err != nil {
 		return Result{err: err}
@@ -191,7 +191,8 @@ func (m *SmbShareManager) Finalize(
 	ctx context.Context,
 	instance *sambaoperatorv1alpha1.SmbShare) Result {
 	// ---
-	cm, err := getConfigMap(ctx, m.client, m.cfg.WorkingNamespace)
+	destNamespace := instance.Namespace
+	cm, err := getConfigMap(ctx, m.client, destNamespace)
 	if err == nil {
 		_, changed, err := m.updateConfiguration(ctx, cm, instance)
 		if err != nil {

--- a/internal/resources/smbshare.go
+++ b/internal/resources/smbshare.go
@@ -232,7 +232,22 @@ func (m *SmbShareManager) getOrCreateDeployment(
 
 	if errors.IsNotFound(err) {
 		// not found - define a new deployment
-		dep := m.deploymentForSmbShare(planner, ns)
+		// labels - do I need them?
+		dep := buildDeployment(
+			m.cfg, planner, planner.SmbShare.Spec.Storage.Pvc.Name, ns)
+		// set the smbshare instance as the owner and controller
+		err = controllerutil.SetControllerReference(
+			planner.SmbShare, dep, m.scheme)
+		if err != nil {
+			m.logger.Error(
+				err,
+				"Failed to set controller reference",
+				"SmbShare.Namespace", planner.SmbShare.Namespace,
+				"SmbShare.Name", planner.SmbShare.Name,
+				"Deployment.Namespace", dep.Namespace,
+				"Deployment.Name", dep.Name)
+			return dep, false, err
+		}
 		m.logger.Info(
 			"Creating a new Deployment",
 			"Deployment.Namespace", dep.Namespace,
@@ -272,13 +287,35 @@ func (m *SmbShareManager) getOrCreatePvc(
 
 	if errors.IsNotFound(err) {
 		// not found - define a new pvc
-		pvc = m.pvcForSmbShare(smbShare, ns)
+		pvc = &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      pvcName(smbShare),
+				Namespace: ns,
+			},
+			Spec: *smbShare.Spec.Storage.Pvc.Spec,
+		}
+		// set the smb share instance as the owner and controller
+		err = controllerutil.SetControllerReference(
+			smbShare, pvc, m.scheme)
+		if err != nil {
+			m.logger.Error(
+				err,
+				"Failed to set controller reference",
+				"SmbShare.Namespace", smbShare.Namespace,
+				"SmbShare.Name", smbShare.Name,
+				"PersistentVolumeClaim.Namespace", pvc.Namespace,
+				"PersistentVolumeClaim.Name", pvc.Name)
+			return pvc, false, err
+		}
 		m.logger.Info("Creating a new PVC",
 			"pvc.Namespace", pvc.Namespace, "pvc.Name", pvc.Name)
 		err = m.client.Create(ctx, pvc)
 		if err != nil {
-			m.logger.Error(err, "Failed to create new PVC",
-				"pvc.Namespace", pvc.Namespace, "pvc.Name", pvc.Name)
+			m.logger.Error(
+				err,
+				"Failed to create new PVC",
+				"PersistentVolumeClaim.Namespace", pvc.Namespace,
+				"PersistentVolumeClaim.Name", pvc.Name)
 			return pvc, false, err
 		}
 		// Pvc created successfully
@@ -309,35 +346,6 @@ func (m *SmbShareManager) updateDeploymentSize(
 	}
 
 	return false, nil
-}
-
-// deploymentForSmbShare returns a smbshare deployment object
-func (m *SmbShareManager) deploymentForSmbShare(
-	planner *sharePlanner, ns string) *appsv1.Deployment {
-	// labels - do I need them?
-	dep := buildDeployment(
-		m.cfg, planner, planner.SmbShare.Spec.Storage.Pvc.Name, ns)
-	// set the smbshare instance as the owner and controller
-	controllerutil.SetControllerReference(planner.SmbShare, dep, m.scheme)
-	return dep
-}
-
-func (m *SmbShareManager) pvcForSmbShare(
-	s *sambaoperatorv1alpha1.SmbShare,
-	ns string) *corev1.PersistentVolumeClaim {
-	// build a new pvc
-	pvc := &corev1.PersistentVolumeClaim{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      pvcName(s),
-			Namespace: ns,
-		},
-		Spec: *s.Spec.Storage.Pvc.Spec,
-	}
-
-	// set the smb share instance as the owner and controller
-	controllerutil.SetControllerReference(s, pvc, m.scheme)
-
-	return pvc
 }
 
 func pvcName(s *sambaoperatorv1alpha1.SmbShare) string {
@@ -512,13 +520,26 @@ func (m *SmbShareManager) getOrCreateService(
 		// not found - define a new deployment
 		svc := newServiceForSmb(planner, ns)
 		// set the smbshare instance as the owner and controller
-		controllerutil.SetControllerReference(planner.SmbShare, svc, m.scheme)
+		err = controllerutil.SetControllerReference(
+			planner.SmbShare, svc, m.scheme)
+		if err != nil {
+			m.logger.Error(
+				err,
+				"Failed to set controller reference",
+				"SmbShare.Namespace", planner.SmbShare.Namespace,
+				"SmbShare.Name", planner.SmbShare.Name,
+				"Service.Namespace", svc.Namespace,
+				"Service.Name", svc.Name)
+			return svc, false, err
+		}
 		m.logger.Info("Creating a new Service",
 			"Service.Namespace", svc.Namespace,
 			"Service.Name", svc.Name)
 		err = m.client.Create(ctx, svc)
 		if err != nil {
-			m.logger.Error(err, "Failed to create new Service",
+			m.logger.Error(
+				err,
+				"Failed to create new Service",
 				"Service.Namespace", svc.Namespace,
 				"Service.Name", svc.Name)
 			return svc, false, err

--- a/tests/integration/smb_share_test.go
+++ b/tests/integration/smb_share_test.go
@@ -284,7 +284,7 @@ func allSmbShareSuites() map[string]suite.TestingSuite {
 		fileSources: []kube.FileSource{
 			{
 				Path:      path.Join(testFilesDir, "userssecret1.yaml"),
-				Namespace: testNamespace,
+				Namespace: "default",
 			},
 			{
 				Path:      path.Join(testFilesDir, "smbsecurityconfig1.yaml"),
@@ -296,6 +296,7 @@ func allSmbShareSuites() map[string]suite.TestingSuite {
 			},
 		},
 		smbShareResource: types.NamespacedName{"default", "tshare3"},
+		destNamespace:    "default",
 		shareName:        "My Other Share",
 		testAuths: []smbclient.Auth{{
 			Username: "sambauser",

--- a/tests/integration/smb_share_test.go
+++ b/tests/integration/smb_share_test.go
@@ -25,6 +25,7 @@ type SmbShareSuite struct {
 	smbShareResource types.NamespacedName
 	shareName        string
 	testAuths        []smbclient.Auth
+	destNamespace    string
 
 	// cached values
 	tc *kube.TestClient
@@ -32,6 +33,9 @@ type SmbShareSuite struct {
 
 func (s *SmbShareSuite) SetupSuite() {
 	// ensure the smbclient test pod exists
+	if s.destNamespace == "" {
+		s.destNamespace = testNamespace
+	}
 	require := s.Require()
 	s.tc = kube.NewTestClient("")
 	for _, fs := range s.fileSources {
@@ -64,7 +68,7 @@ func (s *SmbShareSuite) waitForPodExist() error {
 		ctx,
 		s.tc,
 		fmt.Sprintf("samba-operator.samba.org/service=%s", s.smbShareResource.Name),
-		testNamespace)
+		s.destNamespace)
 }
 
 func (s *SmbShareSuite) waitForPodReady() error {
@@ -76,14 +80,14 @@ func (s *SmbShareSuite) waitForPodReady() error {
 		ctx,
 		s.tc,
 		fmt.Sprintf("samba-operator.samba.org/service=%s", s.smbShareResource.Name),
-		testNamespace)
+		s.destNamespace)
 }
 
 func (s *SmbShareSuite) getPodIP() (string, error) {
 	pod, err := s.tc.GetPodByLabel(
 		context.TODO(),
 		fmt.Sprintf("samba-operator.samba.org/service=%s", s.smbShareResource.Name),
-		testNamespace)
+		s.destNamespace)
 	if err != nil {
 		return "", err
 	}
@@ -110,7 +114,7 @@ func (s *SmbShareSuite) TestShareAccessByIP() {
 func (s *SmbShareSuite) TestShareAccessByServiceName() {
 	svcname := fmt.Sprintf("%s.%s.svc.cluster.local",
 		s.smbShareResource.Name,
-		testNamespace)
+		s.destNamespace)
 	shareAccessSuite := &ShareAccessSuite{
 		share: smbclient.Share{
 			Host: smbclient.Host(svcname),
@@ -189,7 +193,7 @@ func (s *SmbShareWithDNSSuite) TestPodForDNSContainers() {
 	pod, err := s.tc.GetPodByLabel(
 		context.TODO(),
 		fmt.Sprintf("samba-operator.samba.org/service=%s", s.smbShareResource.Name),
-		testNamespace)
+		s.destNamespace)
 	s.Require().NoError(err)
 	s.Require().Equal(4, len(pod.Spec.Containers))
 	names := []string{}
@@ -207,7 +211,7 @@ type SmbShareWithExternalNetSuite struct {
 
 func (s *SmbShareWithExternalNetSuite) TestServiceIsLoadBalancer() {
 	lbl := fmt.Sprintf("samba-operator.samba.org/service=%s", s.smbShareResource.Name)
-	l, err := s.tc.Clientset().CoreV1().Services(testNamespace).List(
+	l, err := s.tc.Clientset().CoreV1().Services(s.destNamespace).List(
 		context.TODO(),
 		metav1.ListOptions{
 			LabelSelector: lbl,


### PR DESCRIPTION
Fixes #87

These changes reverse the well intentioned but incorrect attempt at managing all created resources under the namespace the operator runs in. It restores the previous behavior such that deployments/pods/services/etc will be created in the namespace that the SmbShare resource "owning" those resources is placed in.

This also fixes up the existing "other namespace" test to conform to the new behavior.