### PR TITLE
Use multiple config maps for container config

### DIFF
--- a/internal/resources/configmap.go
+++ b/internal/resources/configmap.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	rtclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -49,30 +48,6 @@ func getConfigMap(
 		},
 		cm)
 	return cm, err
-}
-
-func getOrCreateConfigMap(
-	ctx context.Context, client rtclient.Client, ns string) (
-	*corev1.ConfigMap, bool, error) {
-	// fetch the existing config, if available
-	cm, err := getConfigMap(ctx, client, ns)
-	if err == nil {
-		return cm, false, nil
-	}
-
-	if errors.IsNotFound(err) {
-		cm, err = newDefaultConfigMap(ConfigMapName, ns)
-		if err != nil {
-			return cm, false, err
-		}
-		err = client.Create(ctx, cm)
-		if err != nil {
-			return cm, false, err
-		}
-		// Deployment created successfully
-		return cm, true, nil
-	}
-	return nil, false, err
 }
 
 func newDefaultConfigMap(name, ns string) (*corev1.ConfigMap, error) {

--- a/internal/resources/configmap.go
+++ b/internal/resources/configmap.go
@@ -16,13 +16,10 @@ limitations under the License.
 package resources
 
 import (
-	"context"
 	"encoding/json"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	rtclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/samba-in-kubernetes/samba-operator/internal/smbcc"
 )
@@ -34,21 +31,6 @@ const (
 	// ConfigJSONKey is the name of the key our json is under.
 	ConfigJSONKey = "config.json"
 )
-
-func getConfigMap(
-	ctx context.Context, client rtclient.Client, ns string) (
-	*corev1.ConfigMap, error) {
-	// fetch the existing config, if available
-	cm := &corev1.ConfigMap{}
-	err := client.Get(
-		ctx,
-		types.NamespacedName{
-			Name:      ConfigMapName,
-			Namespace: ns,
-		},
-		cm)
-	return cm, err
-}
 
 func newDefaultConfigMap(name, ns string) (*corev1.ConfigMap, error) {
 	// we use marshal indent so that the json is semi-human-readable

--- a/internal/resources/configmap.go
+++ b/internal/resources/configmap.go
@@ -29,8 +29,9 @@ import (
 )
 
 const (
-	// ConfigMapName is the name of the configmap we store in.
-	ConfigMapName = "samba-container-config"
+	// ConfigMapName is the name of the configmap volume.
+	configMapName = "samba-container-config"
+
 	// ConfigJSONKey is the name of the key our json is under.
 	ConfigJSONKey = "config.json"
 )

--- a/internal/resources/pods.go
+++ b/internal/resources/pods.go
@@ -257,9 +257,9 @@ func configVolumeAndMount(planner *sharePlanner) (
 	corev1.Volume, corev1.VolumeMount) {
 	// volume
 	cmSrc := &corev1.ConfigMapVolumeSource{}
-	cmSrc.Name = ConfigMapName
+	cmSrc.Name = planner.instanceName()
 	volume := corev1.Volume{
-		Name: ConfigMapName,
+		Name: configMapName,
 		VolumeSource: corev1.VolumeSource{
 			ConfigMap: cmSrc,
 		},
@@ -267,7 +267,7 @@ func configVolumeAndMount(planner *sharePlanner) (
 	// mount
 	mount := corev1.VolumeMount{
 		MountPath: planner.containerConfigDir(),
-		Name:      ConfigMapName,
+		Name:      configMapName,
 	}
 	return volume, mount
 }

--- a/internal/resources/smbshare.go
+++ b/internal/resources/smbshare.go
@@ -71,9 +71,11 @@ func (m *SmbShareManager) Process(
 			// Request object not found. Not a fatal error.
 			return Done
 		}
-		m.logger.Error(err, "get failed for SmbShare",
-			"ns", nsname.Namespace,
-			"name", nsname.Name)
+		m.logger.Error(
+			err,
+			"Failed to get SmbShare",
+			"SmbShare.Namespace", nsname.Namespace,
+			"SmbShare.Name", nsname.Name)
 		return Result{err: err}
 	}
 
@@ -95,9 +97,11 @@ func (m *SmbShareManager) Update(
 	ctx context.Context,
 	instance *sambaoperatorv1alpha1.SmbShare) Result {
 	// ---
-	m.logger.Info("Updating state for SmbShare",
-		"name", instance.Name,
-		"UID", instance.UID)
+	m.logger.Info(
+		"Updating state for SmbShare",
+		"SmbShare.Namespace", instance.Namespace,
+		"SmbShare.Name", instance.Name,
+		"SmbShare.UID", instance.UID)
 
 	changed, err := m.addFinalizer(ctx, instance)
 	if err != nil {
@@ -255,6 +259,8 @@ func (m *SmbShareManager) getOrCreateDeployment(
 		}
 		m.logger.Info(
 			"Creating a new Deployment",
+			"SmbShare.Namespace", planner.SmbShare.Namespace,
+			"SmbShare.Name", planner.SmbShare.Name,
 			"Deployment.Namespace", dep.Namespace,
 			"Deployment.Name", dep.Name)
 		err = m.client.Create(ctx, dep)
@@ -262,6 +268,8 @@ func (m *SmbShareManager) getOrCreateDeployment(
 			m.logger.Error(
 				err,
 				"Failed to create new Deployment",
+				"SmbShare.Namespace", planner.SmbShare.Namespace,
+				"SmbShare.Name", planner.SmbShare.Name,
 				"Deployment.Namespace", dep.Namespace,
 				"Deployment.Name", dep.Name)
 			return dep, false, err
@@ -269,7 +277,13 @@ func (m *SmbShareManager) getOrCreateDeployment(
 		// Deployment created successfully
 		return dep, true, nil
 	}
-	m.logger.Error(err, "Failed to get Deployment")
+	m.logger.Error(
+		err,
+		"Failed to get Deployment",
+		"SmbShare.Namespace", planner.SmbShare.Namespace,
+		"SmbShare.Name", planner.SmbShare.Name,
+		"Deployment.Namespace", dep.Namespace,
+		"Deployment.Name", dep.Name)
 	return nil, false, err
 }
 
@@ -312,13 +326,19 @@ func (m *SmbShareManager) getOrCreatePvc(
 				"PersistentVolumeClaim.Name", pvc.Name)
 			return pvc, false, err
 		}
-		m.logger.Info("Creating a new PVC",
-			"pvc.Namespace", pvc.Namespace, "pvc.Name", pvc.Name)
+		m.logger.Info(
+			"Creating a new PVC",
+			"SmbShare.Namespace", smbShare.Namespace,
+			"SmbShare.Name", smbShare.Name,
+			"PersistentVolumeClaim.Namespace", pvc.Namespace,
+			"PersistentVolumeClaim.Name", pvc.Name)
 		err = m.client.Create(ctx, pvc)
 		if err != nil {
 			m.logger.Error(
 				err,
 				"Failed to create new PVC",
+				"SmbShare.Namespace", smbShare.Namespace,
+				"SmbShare.Name", smbShare.Name,
 				"PersistentVolumeClaim.Namespace", pvc.Namespace,
 				"PersistentVolumeClaim.Name", pvc.Name)
 			return pvc, false, err
@@ -326,7 +346,13 @@ func (m *SmbShareManager) getOrCreatePvc(
 		// Pvc created successfully
 		return pvc, true, nil
 	}
-	m.logger.Error(err, "Failed to get PVC")
+	m.logger.Error(
+		err,
+		"Failed to get PVC",
+		"SmbShare.Namespace", smbShare.Namespace,
+		"SmbShare.Name", smbShare.Name,
+		"PersistentVolumeClaim.Namespace", pvc.Namespace,
+		"PersistentVolumeClaim.Name", pvc.Name)
 	return nil, false, err
 }
 
@@ -363,6 +389,8 @@ func (m *SmbShareManager) getOrCreateService(
 			return svc, false, err
 		}
 		m.logger.Info("Creating a new Service",
+			"SmbShare.Namespace", planner.SmbShare.Namespace,
+			"SmbShare.Name", planner.SmbShare.Name,
 			"Service.Namespace", svc.Namespace,
 			"Service.Name", svc.Name)
 		err = m.client.Create(ctx, svc)
@@ -370,6 +398,8 @@ func (m *SmbShareManager) getOrCreateService(
 			m.logger.Error(
 				err,
 				"Failed to create new Service",
+				"SmbShare.Namespace", planner.SmbShare.Namespace,
+				"SmbShare.Name", planner.SmbShare.Name,
 				"Service.Namespace", svc.Namespace,
 				"Service.Name", svc.Name)
 			return svc, false, err
@@ -377,7 +407,13 @@ func (m *SmbShareManager) getOrCreateService(
 		// Deployment created successfully
 		return svc, true, nil
 	}
-	m.logger.Error(err, "Failed to get Service")
+	m.logger.Error(
+		err,
+		"Failed to get Service",
+		"SmbShare.Namespace", planner.SmbShare.Namespace,
+		"SmbShare.Name", planner.SmbShare.Name,
+		"Service.Namespace", svc.Namespace,
+		"Service.Name", svc.Name)
 	return nil, false, err
 }
 

--- a/internal/resources/smbshare.go
+++ b/internal/resources/smbshare.go
@@ -223,7 +223,7 @@ func (m *SmbShareManager) getOrCreateDeployment(
 	err := m.client.Get(
 		ctx,
 		types.NamespacedName{
-			Name:      planner.SmbShare.Name,
+			Name:      planner.instanceName(),
 			Namespace: ns,
 		},
 		found)


### PR DESCRIPTION
Depends on #100  - please review that first

The samba-container is based on a JSON configuration file which gets turned into smb/samba configs and environmental config. Originally, we had "one big config" but this was running counter to the flow of the rest of the operator. On top of that the work to fix the namespaces show that we're going to be creating additional config maps when the resources occur in different namespaces anyway. Using a config map per-SmbShare (instance) let's us tie the lifecycle of the map to the SmbShare and simplify the management of the config.