### PR TITLE
conf: add winbind pod name config parameter

### DIFF
--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -20,6 +20,9 @@ type OperatorConfig struct {
 	// SmbdContainerName can be used to set the name of the primary container,
 	// the one running smbd, in the pod.
 	SmbdContainerName string `mapstructure:"smbd-container-name"`
+	// WinbindContainerName can be used to the the name of the container
+	// running winbind.
+	WinbindContainerName string `mapstructure:"winbind-container-name"`
 	// WorkingNamespace defines the namespace the operator will (generally)
 	// make changes in.
 	WorkingNamespace string `mapstructure:"working-namespace"`
@@ -54,6 +57,7 @@ func NewSource() *Source {
 		"smbd-container-image",
 		"quay.io/samba.org/samba-server:latest")
 	v.SetDefault("smbd-container-name", "samba")
+	v.SetDefault("winbind-container-name", "wb")
 	v.SetDefault("working-namespace", "")
 	v.SetDefault(
 		"svc-watch-container-image",

--- a/internal/resources/pods.go
+++ b/internal/resources/pods.go
@@ -109,7 +109,7 @@ func buildADPodSpec(
 			},
 			{
 				Image:        cfg.SmbdContainerImage,
-				Name:         "wb", //cfg.WinbindContainerName,
+				Name:         cfg.WinbindContainerName,
 				Args:         []string{"run", "winbindd"},
 				Env:          podEnv,
 				VolumeMounts: append(sharedMounts, wbSockVol.mount),


### PR DESCRIPTION
Similar to the to the smb container name parameter this is mainly meant
for testing. Fixes a long standing TODO in the code.

Signed-off-by: John Mulligan <jmulligan@redhat.com>