### PR TITLE
test utils: add more flexible utility functions

### DIFF
--- a/tests/integration/deploy_test.go
+++ b/tests/integration/deploy_test.go
@@ -4,7 +4,6 @@ package integration
 
 import (
 	"context"
-	"fmt"
 	"os/exec"
 	"path"
 	"time"
@@ -53,17 +52,24 @@ func (s DeploySuite) TestOperatorReady() {
 		context.TODO(),
 		time.Now().Add(90*time.Second))
 	defer cancel()
-	err := kube.WaitForPodExistsByLabel(
+	l := "control-plane=controller-manager"
+	err := kube.WaitForAnyPodExists(
 		ctx,
 		s.tc,
-		fmt.Sprintf("control-plane=controller-manager"),
-		testNamespace)
+		kube.PodFetchOptions{
+			Namespace:     testNamespace,
+			LabelSelector: l,
+		},
+	)
 	s.Require().NoError(err)
-	err = kube.WaitForPodReadyByLabel(
+	err = kube.WaitForAnyPodReady(
 		ctx,
 		s.tc,
-		fmt.Sprintf("control-plane=controller-manager"),
-		testNamespace)
+		kube.PodFetchOptions{
+			Namespace:     testNamespace,
+			LabelSelector: l,
+		},
+	)
 	s.Require().NoError(err)
 }
 

--- a/tests/integration/share_access_test.go
+++ b/tests/integration/share_access_test.go
@@ -46,18 +46,23 @@ func (s *ShareAccessSuite) SetupSuite() {
 		context.TODO(),
 		time.Now().Add(120*time.Second))
 	defer cancel()
-	s.Require().NoError(kube.WaitForPodExistsByLabel(
+	l := "app=samba-operator-test-smbclient"
+	s.Require().NoError(kube.WaitForAnyPodExists(
 		ctx,
 		kube.NewTestClient(""),
-		"app=samba-operator-test-smbclient",
-		testNamespace),
+		kube.PodFetchOptions{
+			Namespace:     testNamespace,
+			LabelSelector: l,
+		}),
 		"smbclient pod does not exist",
 	)
-	s.Require().NoError(kube.WaitForPodReadyByLabel(
+	s.Require().NoError(kube.WaitForAnyPodReady(
 		ctx,
 		kube.NewTestClient(""),
-		"app=samba-operator-test-smbclient",
-		testNamespace),
+		kube.PodFetchOptions{
+			Namespace:     testNamespace,
+			LabelSelector: l,
+		}),
 		"smbclient pod not ready",
 	)
 }

--- a/tests/integration/smb_share_test.go
+++ b/tests/integration/smb_share_test.go
@@ -96,14 +96,19 @@ func (s *SmbShareSuite) waitForPodReady() error {
 }
 
 func (s *SmbShareSuite) getPodIP() (string, error) {
-	pod, err := s.tc.GetPodByLabel(
+	l := fmt.Sprintf(
+		"samba-operator.samba.org/service=%s", s.smbShareResource.Name)
+	pods, err := s.tc.FetchPods(
 		context.TODO(),
-		fmt.Sprintf("samba-operator.samba.org/service=%s", s.smbShareResource.Name),
-		s.destNamespace)
+		kube.PodFetchOptions{
+			Namespace:     s.destNamespace,
+			LabelSelector: l,
+		},
+	)
 	if err != nil {
 		return "", err
 	}
-	return pod.Status.PodIP, nil
+	return pods[0].Status.PodIP, nil
 }
 
 func (s *SmbShareSuite) TestPodsReady() {
@@ -211,14 +216,19 @@ func (s *SmbShareWithDNSSuite) TestShareAccessByDomainName() {
 }
 
 func (s *SmbShareWithDNSSuite) TestPodForDNSContainers() {
-	pod, err := s.tc.GetPodByLabel(
+	l := fmt.Sprintf(
+		"samba-operator.samba.org/service=%s", s.smbShareResource.Name)
+	pods, err := s.tc.FetchPods(
 		context.TODO(),
-		fmt.Sprintf("samba-operator.samba.org/service=%s", s.smbShareResource.Name),
-		s.destNamespace)
+		kube.PodFetchOptions{
+			Namespace:     s.destNamespace,
+			LabelSelector: l,
+		},
+	)
 	s.Require().NoError(err)
-	s.Require().Equal(4, len(pod.Spec.Containers))
+	s.Require().Equal(4, len(pods[0].Spec.Containers))
 	names := []string{}
-	for _, cstatus := range pod.Status.ContainerStatuses {
+	for _, cstatus := range pods[0].Status.ContainerStatuses {
 		names = append(names, cstatus.Name)
 		s.Require().True(cstatus.Ready)
 	}

--- a/tests/integration/smb_share_test.go
+++ b/tests/integration/smb_share_test.go
@@ -66,11 +66,16 @@ func (s *SmbShareSuite) waitForPodExist() error {
 		context.TODO(),
 		time.Now().Add(10*time.Second))
 	defer cancel()
-	return kube.WaitForPodExistsByLabel(
+	l := fmt.Sprintf(
+		"samba-operator.samba.org/service=%s", s.smbShareResource.Name)
+	return kube.WaitForAnyPodExists(
 		ctx,
 		s.tc,
-		fmt.Sprintf("samba-operator.samba.org/service=%s", s.smbShareResource.Name),
-		s.destNamespace)
+		kube.PodFetchOptions{
+			Namespace:     s.destNamespace,
+			LabelSelector: l,
+		},
+	)
 }
 
 func (s *SmbShareSuite) waitForPodReady() error {
@@ -78,11 +83,16 @@ func (s *SmbShareSuite) waitForPodReady() error {
 		context.TODO(),
 		time.Now().Add(60*time.Second))
 	defer cancel()
-	return kube.WaitForPodReadyByLabel(
+	l := fmt.Sprintf(
+		"samba-operator.samba.org/service=%s", s.smbShareResource.Name)
+	return kube.WaitForAnyPodReady(
 		ctx,
 		s.tc,
-		fmt.Sprintf("samba-operator.samba.org/service=%s", s.smbShareResource.Name),
-		s.destNamespace)
+		kube.PodFetchOptions{
+			Namespace:     s.destNamespace,
+			LabelSelector: l,
+		},
+	)
 }
 
 func (s *SmbShareSuite) getPodIP() (string, error) {

--- a/tests/utils/kube/client.go
+++ b/tests/utils/kube/client.go
@@ -161,3 +161,63 @@ func WaitForPodExistsByLabel(
 	}
 	return nil
 }
+
+func waitFor(ctx context.Context, cond func() (bool, error)) error {
+	for {
+		c, err := cond()
+		if err != nil {
+			return err
+		}
+		if c {
+			break
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	return nil
+}
+
+// WaitForAnyPodReady will wait for a pod to be ready, up to the deadline
+// specified by the context, if the context lacks a deadline the call will
+// block indefinitely. Pods are selected using the PodFetchOptions.
+func WaitForAnyPodReady(
+	ctx context.Context, tc *TestClient, fo PodFetchOptions) error {
+	// ---
+	return waitFor(
+		ctx,
+		func() (bool, error) {
+			pods, err := tc.FetchPods(ctx, fo)
+			if err != nil {
+				return false, err
+			}
+			for _, pod := range pods {
+				if PodIsReady(&pod) {
+					return true, nil
+				}
+			}
+			return false, nil
+		},
+	)
+}
+
+// WaitForAnyPodExists will wait for a pod to exist, up to the deadline
+// specified by the context, if the context lacks a deadline the call will
+// block indefinitely. Pods are selected using the PodFetchOptions.
+func WaitForAnyPodExists(
+	ctx context.Context, tc *TestClient, fo PodFetchOptions) error {
+	// ---
+	return waitFor(
+		ctx,
+		func() (bool, error) {
+			_, err := tc.FetchPods(ctx, fo)
+			if err == nil {
+				return true, nil
+			} else if errors.Is(err, ErrNoMatchingPods) {
+				return false, nil
+			}
+			return false, err
+		},
+	)
+}


### PR DESCRIPTION
The old utility functions were fine but could only _ever_ operate on/handle a single pod. If & when we need to handle multiple pods these functions are too inflexible. Replace the old utility functions with more flexible, but still convenient, versions.