### PR TITLE
config: user newer kube-rbac-proxy image

### DIFF
--- a/config/manager-full/auth_proxy_patch.yaml
+++ b/config/manager-full/auth_proxy_patch.yaml
@@ -10,7 +10,12 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        # this is apparently the same code as
+        # https://github.com/brancz/kube-rbac-proxy/
+        # but build by/for kubebuilder. The brancz repo also has
+        # newer releases but v0.8 is the lastest at this repo
+        # according to skopeo on 2021-11-06.
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
A downside of consuming a bunch of generated stuff is you don't know exactly why or what you're relying on. This bumps the version of the kube-rbac-proxy sidecar used and leaves a comment to hopefully have a better idea about what we're consuming.