### PR TITLE
Test enabling loadbalancer services when using clustered instances

### DIFF
--- a/tests/files/smbshare_ctdb3.yaml
+++ b/tests/files/smbshare_ctdb3.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: samba-operator.samba.org/v1alpha1
+kind: SmbShare
+metadata:
+  name: cshare3
+  annotations:
+    samba-operator.samba.org/node-spread: "false"
+spec:
+  shareName: "Costly Hare"
+  readOnly: false
+  browseable: true
+  commonConfig: commonext1
+  securityConfig: adsec1
+  scaling:
+    availabilityMode: clustered
+    minClusterSize: 2
+  storage:
+    pvc:
+      spec:
+        accessModes:
+          - ReadWriteMany
+        resources:
+          requests:
+            storage: 1Gi

--- a/tests/integration/smb_share_test.go
+++ b/tests/integration/smb_share_test.go
@@ -447,6 +447,35 @@ func allSmbShareSuites() map[string]suite.TestingSuite {
 				Password: "1115Rose.",
 			}},
 		}}
+		m["smbSharesClusteredExternal"] = &SmbShareWithExternalNetSuite{SmbShareSuite{
+			fileSources: []kube.FileSource{
+				{
+					Path:      path.Join(testFilesDir, "joinsecret1.yaml"),
+					Namespace: testNamespace,
+				},
+				{
+					Path:      path.Join(testFilesDir, "commonconfig1.yaml"),
+					Namespace: testNamespace,
+				},
+				{
+					Path:      path.Join(testFilesDir, "smbsecurityconfig2.yaml"),
+					Namespace: testNamespace,
+				},
+				{
+					Path:       path.Join(testFilesDir, "smbshare_ctdb3.yaml"),
+					Namespace:  testNamespace,
+					NameSuffix: "-exlb",
+				},
+			},
+			smbShareResource: types.NamespacedName{testNamespace, "cshare3-exlb"},
+			maxPods:          3,
+			minPods:          2,
+			shareName:        "Costly Hare",
+			testAuths: []smbclient.Auth{{
+				Username: "DOMAIN1\\bwayne",
+				Password: "1115Rose.",
+			}},
+		}}
 	}
 
 	return m


### PR DESCRIPTION
Depends on #126 

Fixes #117 

Add basic testing for load balancer enabled services. As before, we don't actually test that the external lb svc does anything
as we don't have the test infra for that. That can only be testedmanually at the moment.

I did that locally and everything seems OK so far.

