### PR TITLE
Adding vfs_fileid changes to the samba-operator

### DIFF
--- a/internal/resources/planner.go
+++ b/internal/resources/planner.go
@@ -241,10 +241,10 @@ func (sp *sharePlanner) idmapOptions() smbcc.SmbOptions {
 }
 
 func (sp *sharePlanner) update() (changed bool, err error) {
-	noprinting, found := sp.ConfigState.Globals[smbcc.NoPrintingKey]
+	globals, found := sp.ConfigState.Globals[smbcc.Globals]
 	if !found {
-		noprinting = smbcc.NewNoPrintingGlobals()
-		sp.ConfigState.Globals[smbcc.NoPrintingKey] = noprinting
+		globals = smbcc.NewGlobals()
+		sp.ConfigState.Globals[smbcc.Globals] = globals
 		changed = true
 	}
 	shareKey := smbcc.Key(sp.shareName())
@@ -265,7 +265,7 @@ func (sp *sharePlanner) update() (changed bool, err error) {
 	if !found || cfg.Shares[0] != shareKey {
 		cfg = smbcc.ConfigSection{
 			Shares:       []smbcc.Key{shareKey},
-			Globals:      []smbcc.Key{smbcc.NoPrintingKey},
+			Globals:      []smbcc.Key{smbcc.Globals},
 			InstanceName: sp.instanceName(),
 		}
 		if sp.securityMode() == adMode {

--- a/internal/resources/planner.go
+++ b/internal/resources/planner.go
@@ -243,7 +243,8 @@ func (sp *sharePlanner) idmapOptions() smbcc.SmbOptions {
 func (sp *sharePlanner) update() (changed bool, err error) {
 	globals, found := sp.ConfigState.Globals[smbcc.Globals]
 	if !found {
-		globals = smbcc.NewGlobals()
+		globalOptions := smbcc.NewGlobalOptions()
+		globals = smbcc.NewGlobals(globalOptions)
 		sp.ConfigState.Globals[smbcc.Globals] = globals
 		changed = true
 	}

--- a/internal/smbcc/container_config.go
+++ b/internal/smbcc/container_config.go
@@ -27,6 +27,12 @@ const (
 	CTDB FeatureFlag = "ctdb"
 )
 
+// GlobalOptions is used to pass options to modify the samba configuration
+type GlobalOptions struct {
+	// AddVFSFileid is used to check if we add vfs_fileid to the smb config
+	AddVFSFileid bool
+}
+
 // SambaContainerConfig holds one or more configuration for samba
 // containers.
 type SambaContainerConfig struct {
@@ -101,6 +107,13 @@ const (
 	No = "no"
 )
 
+// NewGlobalOptions is the constructor for struct SambaConfigOptions
+func NewGlobalOptions() GlobalOptions {
+	return GlobalOptions{
+		AddVFSFileid: true,
+	}
+}
+
 // New returns a new samba container config.
 func New() *SambaContainerConfig {
 	return &SambaContainerConfig{
@@ -112,8 +125,8 @@ func New() *SambaContainerConfig {
 }
 
 // NewGlobals returns a default GlobalConfig.
-func NewGlobals() GlobalConfig {
-	return GlobalConfig{
+func NewGlobals(opts GlobalOptions) GlobalConfig {
+	cfg := GlobalConfig{
 		Options: SmbOptions{
 			"load printers":   No,
 			"printing":        "bsd",
@@ -121,6 +134,18 @@ func NewGlobals() GlobalConfig {
 			"disable spoolss": Yes,
 		},
 	}
+
+	if opts.AddVFSFileid {
+		_, found := cfg.Options["vfs objects"]
+		if found {
+			cfg.Options["vfs objects"] += " fileid"
+		} else {
+			cfg.Options["vfs objects"] = "fileid"
+		}
+		cfg.Options["fileid:algorithm"] = "fsid"
+	}
+
+	return cfg
 }
 
 // NewSimpleShare returns a ShareConfig with a simple configuration.

--- a/internal/smbcc/container_config.go
+++ b/internal/smbcc/container_config.go
@@ -84,8 +84,8 @@ type SmbOptions map[string]string
 const version0 = "v0"
 
 const (
-	// NoPrintingKey is used for the standard "noprinting" globals subsection.
-	NoPrintingKey = Key("noprinting")
+	// Globals is used for the default globals subsection.
+	Globals = Key("globals")
 	// AllEntriesKey is used for the standard "all_entries" default key for
 	// users and groups.
 	AllEntriesKey = Key("all_entries")
@@ -111,8 +111,8 @@ func New() *SambaContainerConfig {
 	}
 }
 
-// NewNoPrintingGlobals returns a GlobalConfig that disables printing.
-func NewNoPrintingGlobals() GlobalConfig {
+// NewGlobals returns a default GlobalConfig.
+func NewGlobals() GlobalConfig {
 	return GlobalConfig{
 		Options: SmbOptions{
 			"load printers":   No,

--- a/internal/smbcc/container_config_test.go
+++ b/internal/smbcc/container_config_test.go
@@ -84,7 +84,8 @@ func TestMarshal(t *testing.T) {
 	globalsKey := Key("globals")
 	shareKey := Key("share")
 	wbtestKey := Key("wbtest")
-	scc.Globals[globalsKey] = NewGlobals()
+	opts := NewGlobalOptions()
+	scc.Globals[globalsKey] = NewGlobals(opts)
 	scc.Globals[wbtestKey] = GlobalConfig{
 		Options: SmbOptions{
 			"log level":                "10",

--- a/internal/smbcc/container_config_test.go
+++ b/internal/smbcc/container_config_test.go
@@ -81,10 +81,10 @@ func TestUnmarshal(t *testing.T) {
 
 func TestMarshal(t *testing.T) {
 	scc := New()
-	noprintingKey := Key("noprinting")
+	globalsKey := Key("globals")
 	shareKey := Key("share")
 	wbtestKey := Key("wbtest")
-	scc.Globals[noprintingKey] = NewNoPrintingGlobals()
+	scc.Globals[globalsKey] = NewGlobals()
 	scc.Globals[wbtestKey] = GlobalConfig{
 		Options: SmbOptions{
 			"log level":                "10",
@@ -99,7 +99,7 @@ func TestMarshal(t *testing.T) {
 	scc.Shares[shareKey] = NewSimpleShare("/path")
 	cfg := NewConfigSection("WB1")
 	cfg.Shares = []Key{shareKey}
-	cfg.Globals = []Key{noprintingKey, wbtestKey}
+	cfg.Globals = []Key{globalsKey, wbtestKey}
 	scc.Configs[wbtestKey] = cfg
 
 	b, err := json.Marshal(scc)


### PR DESCRIPTION
Tested by building the operator image, pushing it to a remote repo and then deploying that remote repo. Confirmed the change by checking the operator logs for the commit id. Once the smbshare was created, I did a kubectl exec into it and checked the generated smb.conf file using the net conf list command 

This set of patches contains two changes.
1) Remove mention of No Printing and
2) Add the fileid plugin based on a global conf set. This can be replaced by intelligence to check for vfs_fileid requirements in the future.