### PR TITLE
api: Fix spelling for SmbShareScalingSpec.AvailabilityMode

### DIFF
--- a/api/v1alpha1/smbshare_types.go
+++ b/api/v1alpha1/smbshare_types.go
@@ -90,11 +90,11 @@ type SmbSharePvcSpec struct {
 
 // SmbShareScalingSpec defines scaling parameters for a share.
 type SmbShareScalingSpec struct {
-	// AvailbilityMode specifies how the operator is to scale share resources
+	// AvailabilityMode specifies how the operator is to scale share resources
 	// for (high-)availability purposes.
 	// +optional
 	// +kubebuilder:validation:Enum:=standard;clustered
-	AvailbilityMode string `json:"availabilityMode,omitempty"`
+	AvailabilityMode string `json:"availabilityMode,omitempty"`
 	// MinClusterSize specifies the minimum number of smb server instances
 	// to establish when availabilityMode is "clustered".
 	MinClusterSize int `json:"minClusterSize,omitempty"`

--- a/config/crd/bases/samba-operator.samba.org_smbshares.yaml
+++ b/config/crd/bases/samba-operator.samba.org_smbshares.yaml
@@ -57,7 +57,7 @@ spec:
                   can and should be scaled.
                 properties:
                   availabilityMode:
-                    description: AvailbilityMode specifies how the operator is to
+                    description: AvailabilityMode specifies how the operator is to
                       scale share resources for (high-)availability purposes.
                     enum:
                     - standard

--- a/docs/design/crd-proposal-phase1.md
+++ b/docs/design/crd-proposal-phase1.md
@@ -128,7 +128,7 @@ Spec Options:
       migration. The "clustered" availability mode enables smb aware clustering
       mechanisms.
     * `minClusterSize` - int - Minimum number of smbd instances when clustered
-      for High-Availbility.
+      for High-Availability.
     * TBD - other clustering specific options
 * `customConfig` - mapping - A new subsection used to load "non-supported" settings
    * `name` - Name of a ConfigMap. TBD - how to express options in the config map.

--- a/internal/resources/planner.go
+++ b/internal/resources/planner.go
@@ -439,7 +439,7 @@ func (sp *sharePlanner) isClustered() bool {
 	if sp.SmbShare.Spec.Scaling == nil {
 		return false
 	}
-	return sp.SmbShare.Spec.Scaling.AvailbilityMode == "clustered"
+	return sp.SmbShare.Spec.Scaling.AvailabilityMode == "clustered"
 }
 
 func (sp *sharePlanner) clusterSize() int32 {

--- a/tests/integration/reconcile_test.go
+++ b/tests/integration/reconcile_test.go
@@ -68,7 +68,7 @@ func (s *limitAvailModeChangeSuite) TestAvailModeUnchanged() {
 	if smbShare.Spec.Scaling == nil {
 		smbShare.Spec.Scaling = &sambaoperatorv1alpha1.SmbShareScalingSpec{}
 	}
-	smbShare.Spec.Scaling.AvailbilityMode = s.nextMode
+	smbShare.Spec.Scaling.AvailabilityMode = s.nextMode
 	smbShare.Spec.Scaling.MinClusterSize = 2
 
 	err = s.tc.TypedObjectClient().Update(


### PR DESCRIPTION
Inconsistency in struct name and json entry.

Signed-off-by: Sachin Prabhu <sprabhu@redhat.com>