### PR TITLE
Improve developer workflow in makefile and docs

### DIFF
--- a/docs/developers-notes.md
+++ b/docs/developers-notes.md
@@ -69,11 +69,19 @@ We also support a "shortcut" location for developers at
 used by the Makefile when variable DEVELOPER is set, for example
 `make DEVELOPER=1 deploy`. Files in the `config/developer` directory
 are ignored by git and are a good place for setting changes that
-are specific to you.
+are specific to you. You can create a developer config with default
+settings by running `make developer-dir DEVELOPER=1`. If you are already
+familiar with kustomize, feel free to populate the kustomization.yaml
+with whatever settings you desire.
 
 An example of custom configuration parameters using kustomize:
 
 ```
+$ make developer-dir DEVELOPER=1
+$ $EDITOR config/developer/kustomization.yaml
+```
+```
+# ^^^ append to default config/developer/kustomization.yaml ^^^ #
 configMapGenerator:
 - behavior: merge
   literals:
@@ -101,6 +109,11 @@ images. We will set the environment variables using kustomize to alter
 the container image used for samba server instances:
 
 ```
+$ make developer-dir DEVELOPER=1
+$ $EDITOR config/developer/kustomization.yaml
+```
+```
+# ^^^ append to default config/developer/kustomization.yaml ^^^ #
 configMapGenerator:
 - behavior: merge
   literals:
@@ -119,6 +132,11 @@ the evnironment. The value should be a numeral 0 through 10 specified as a
 
 
 ```
+$ make developer-dir DEVELOPER=1
+$ $EDITOR config/developer/kustomization.yaml
+```
+```
+# ^^^ append to default config/developer/kustomization.yaml ^^^ #
 configMapGenerator:
 - behavior: merge
   literals:
@@ -134,6 +152,11 @@ enable this experimental feature the environment variable
 `SAMBA_OP_CLUSTER_SUPPORT` must be set to `ctdb-is-experimental`:
 
 ```
+$ make developer-dir DEVELOPER=1
+$ $EDITOR config/developer/kustomization.yaml
+```
+```
+# ^^^ append to default config/developer/kustomization.yaml ^^^ #
 configMapGenerator:
 - behavior: merge
   literals:

--- a/docs/developers-notes.md
+++ b/docs/developers-notes.md
@@ -3,7 +3,8 @@
 
 ## Running a custom operator
 
-As noted in the [README](../README.md) the operator can be deployed using a custom image. This section elaborates on that.
+As noted in the [README](../README.md) the operator can be deployed using a
+custom image. This section elaborates on that.
 
 The makefile is aware of two variables (env vars or directly used by `make`):
 * TAG - specify a custom tag for your container image

--- a/tests/integration/deploy_test.go
+++ b/tests/integration/deploy_test.go
@@ -34,7 +34,7 @@ func (s DeploySuite) createKustomized(dir string) {
 	stdout, err := cmd.StdoutPipe()
 	s.Require().NoError(err)
 	err = cmd.Start()
-	s.Require().NoError(err)
+	s.Require().NoError(err, "kustomize command failed to start")
 	_, err = s.tc.CreateFromFileIfMissing(
 		context.TODO(),
 		kube.DirectSource{
@@ -42,9 +42,9 @@ func (s DeploySuite) createKustomized(dir string) {
 			Namespace: testNamespace,
 		},
 	)
-	s.Require().NoError(err)
+	s.Require().NoError(err, "CreateFromFileIfMissing failed")
 	err = cmd.Wait()
-	s.Require().NoError(err)
+	s.Require().NoError(err, "kustomize command failed")
 }
 
 func (s DeploySuite) TestOperatorReady() {


### PR DESCRIPTION
Previously, the docs didn't explain that the example YAML snippets were to be added to a stock kustomization.yaml, nor did it explain that the makefile could help create this kustomization.yaml.
Now we  can easily initialize the developer dir with `make developer-dir DEVELOPER=1` and we improve the docs to match.

Fixes: #136