### PR TITLE
OpenShift deploy

### DIFF
--- a/config/openshift/kustomization.yaml
+++ b/config/openshift/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - serviceaccount.yaml
+  - sccrolebinding.yaml

--- a/config/openshift/sccrolebinding.yaml
+++ b/config/openshift/sccrolebinding.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: samba-anyuid
+rules:
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - anyuid
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: samba-anyuid
+subjects:
+  - kind: ServiceAccount
+    name: samba
+roleRef:
+  kind: Role
+  name: samba-anyuid
+  apiGroup: rbac.authorization.k8s.io

--- a/config/openshift/serviceaccount.yaml
+++ b/config/openshift/serviceaccount.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: samba

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -8,6 +8,20 @@ import (
 	"github.com/spf13/viper"
 )
 
+// DefaultOperatorConfig holds the default values of OperatorConfig.
+var DefaultOperatorConfig = OperatorConfig{
+	SmbdContainerImage:     "quay.io/samba.org/samba-server:latest",
+	SvcWatchContainerImage: "quay.io/samba.org/svcwatch:latest",
+	SmbdContainerName:      "samba",
+	WinbindContainerName:   "wb",
+	WorkingNamespace:       "",
+	SambaDebugLevel:        "",
+	StatePVCSize:           "1Gi",
+	ClusterSupport:         "",
+	SmbServicePort:         445,
+	SmbdPort:               445,
+}
+
 // OperatorConfig is a type holding general configuration values.
 // Most of the operator code that needs to reference configuration
 // should do so via this type.
@@ -35,6 +49,12 @@ type OperatorConfig struct {
 	// ClusterSupport is a (string) value that indicates if the operator
 	// will be allowed to set up clustered instances.
 	ClusterSupport string `mapstructure:"cluster-support"`
+	// SmbServicePort is an (integer) value that defines the port number which
+	// the kubernetes service exports
+	SmbServicePort int `mapstructure:"smb-service-port"`
+	// SmbdPort is an (integer) value that defines the port number on which
+	// smbd binds and serve.
+	SmbdPort int `mapstructure:"smbd-port"`
 }
 
 // Validate the OperatorConfig returning an error if the config is not
@@ -47,6 +67,14 @@ func (oc *OperatorConfig) Validate() error {
 		return fmt.Errorf(
 			"WorkingNamespace value [%s] invalid", oc.WorkingNamespace)
 	}
+	if oc.SmbServicePort <= 0 {
+		return fmt.Errorf(
+			"SmbPort value [%d] invalid", oc.SmbServicePort)
+	}
+	if oc.SmbdPort <= 0 {
+		return fmt.Errorf(
+			"SmbPort value [%d] invalid", oc.SmbdPort)
+	}
 	return nil
 }
 
@@ -58,19 +86,18 @@ type Source struct {
 
 // NewSource creates a new Source based on default configuration values.
 func NewSource() *Source {
+	d := DefaultOperatorConfig
 	v := viper.New()
-	v.SetDefault(
-		"smbd-container-image",
-		"quay.io/samba.org/samba-server:latest")
-	v.SetDefault("smbd-container-name", "samba")
-	v.SetDefault("winbind-container-name", "wb")
-	v.SetDefault("working-namespace", "")
-	v.SetDefault(
-		"svc-watch-container-image",
-		"quay.io/samba.org/svcwatch:latest")
-	v.SetDefault("samba-debug-level", "")
-	v.SetDefault("state-pvc-size", "1Gi")
-	v.SetDefault("cluster-support", "")
+	v.SetDefault("smbd-container-image", d.SmbdContainerImage)
+	v.SetDefault("smbd-container-name", d.SmbdContainerName)
+	v.SetDefault("winbind-container-name", d.WinbindContainerName)
+	v.SetDefault("working-namespace", d.WorkingNamespace)
+	v.SetDefault("svc-watch-container-image", d.SvcWatchContainerImage)
+	v.SetDefault("samba-debug-level", d.SambaDebugLevel)
+	v.SetDefault("state-pvc-size", d.StatePVCSize)
+	v.SetDefault("cluster-support", d.ClusterSupport)
+	v.SetDefault("smb-service-port", d.SmbServicePort)
+	v.SetDefault("smbd-port", d.SmbdPort)
 	return &Source{v: v}
 }
 

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -55,6 +55,9 @@ type OperatorConfig struct {
 	// SmbdPort is an (integer) value that defines the port number on which
 	// smbd binds and serve.
 	SmbdPort int `mapstructure:"smbd-port"`
+	// ServiceAccountName is a (string) which overrides the default service
+	// account associated with child pods. Required in OpenShift.
+	ServiceAccountName string `mapstructure:"service-account-name"`
 }
 
 // Validate the OperatorConfig returning an error if the config is not
@@ -98,6 +101,7 @@ func NewSource() *Source {
 	v.SetDefault("cluster-support", d.ClusterSupport)
 	v.SetDefault("smb-service-port", d.SmbServicePort)
 	v.SetDefault("smbd-port", d.SmbdPort)
+	v.SetDefault("service-account-name", d.ServiceAccountName)
 	return &Source{v: v}
 }
 

--- a/internal/resources/planner.go
+++ b/internal/resources/planner.go
@@ -244,6 +244,7 @@ func (sp *sharePlanner) update() (changed bool, err error) {
 	globals, found := sp.ConfigState.Globals[smbcc.Globals]
 	if !found {
 		globalOptions := smbcc.NewGlobalOptions()
+		globalOptions.SmbPort = sp.GlobalConfig.SmbdPort
 		globals = smbcc.NewGlobals(globalOptions)
 		sp.ConfigState.Globals[smbcc.Globals] = globals
 		changed = true

--- a/internal/resources/pods.go
+++ b/internal/resources/pods.go
@@ -436,27 +436,28 @@ func buildSmbdCtr(
 	env []corev1.EnvVar,
 	vols []volMount) corev1.Container {
 	// ---
+	portnum := planner.GlobalConfig.SmbdPort
 	return corev1.Container{
 		Image: planner.GlobalConfig.SmbdContainerImage,
 		Name:  planner.GlobalConfig.SmbdContainerName,
 		Args:  planner.runDaemonArgs("smbd"),
 		Env:   env,
 		Ports: []corev1.ContainerPort{{
-			ContainerPort: 445,
+			ContainerPort: int32(portnum),
 			Name:          "smb",
 		}},
 		VolumeMounts: getMounts(vols),
 		ReadinessProbe: &corev1.Probe{
 			Handler: corev1.Handler{
 				TCPSocket: &corev1.TCPSocketAction{
-					Port: intstr.FromInt(445),
+					Port: intstr.FromInt(portnum),
 				},
 			},
 		},
 		LivenessProbe: &corev1.Probe{
 			Handler: corev1.Handler{
 				TCPSocket: &corev1.TCPSocketAction{
-					Port: intstr.FromInt(445),
+					Port: intstr.FromInt(portnum),
 				},
 			},
 		},

--- a/internal/resources/pods.go
+++ b/internal/resources/pods.go
@@ -438,10 +438,11 @@ func buildSmbdCtr(
 	// ---
 	portnum := planner.GlobalConfig.SmbdPort
 	return corev1.Container{
-		Image: planner.GlobalConfig.SmbdContainerImage,
-		Name:  planner.GlobalConfig.SmbdContainerName,
-		Args:  planner.runDaemonArgs("smbd"),
-		Env:   env,
+		Image:   planner.GlobalConfig.SmbdContainerImage,
+		Name:    planner.GlobalConfig.SmbdContainerName,
+		Command: []string{"samba-container"},
+		Args:    planner.runDaemonArgs("smbd"),
+		Env:     env,
 		Ports: []corev1.ContainerPort{{
 			ContainerPort: int32(portnum),
 			Name:          "smb",

--- a/internal/resources/services.go
+++ b/internal/resources/services.go
@@ -18,6 +18,7 @@ package resources
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 var svcSelectorKey = "samba-operator.samba.org/service"
@@ -33,9 +34,10 @@ func newServiceForSmb(planner *sharePlanner, ns string) *corev1.Service {
 		Spec: corev1.ServiceSpec{
 			Type: toServiceType(planner.serviceType()),
 			Ports: []corev1.ServicePort{{
-				Name:     "smb",
-				Protocol: corev1.ProtocolTCP,
-				Port:     445,
+				Name:       "smb",
+				Protocol:   corev1.ProtocolTCP,
+				Port:       int32(planner.GlobalConfig.SmbServicePort),
+				TargetPort: intstr.FromInt(planner.GlobalConfig.SmbdPort),
 			}},
 			Selector: map[string]string{
 				svcSelectorKey: labels[svcSelectorKey],

--- a/internal/smbcc/container_config.go
+++ b/internal/smbcc/container_config.go
@@ -15,6 +15,8 @@ limitations under the License.
 
 package smbcc
 
+import "strconv"
+
 // Key values are used to select subsections in the container config.
 type Key string
 
@@ -25,12 +27,17 @@ type FeatureFlag string
 const (
 	// CTDB feature flag indicates the system should be configured with CTDB.
 	CTDB FeatureFlag = "ctdb"
+
+	// DefaultSmbPort is the default port which containerized smbd binds to.
+	DefaultSmbPort int = 445
 )
 
 // GlobalOptions is used to pass options to modify the samba configuration
 type GlobalOptions struct {
 	// AddVFSFileid is used to check if we add vfs_fileid to the smb config
 	AddVFSFileid bool
+	// SmbPort is used as value to 'smb ports' config
+	SmbPort int
 }
 
 // SambaContainerConfig holds one or more configuration for samba
@@ -111,6 +118,7 @@ const (
 func NewGlobalOptions() GlobalOptions {
 	return GlobalOptions{
 		AddVFSFileid: true,
+		SmbPort:      DefaultSmbPort,
 	}
 }
 
@@ -132,6 +140,7 @@ func NewGlobals(opts GlobalOptions) GlobalConfig {
 			"printing":        "bsd",
 			"printcap name":   "/dev/null",
 			"disable spoolss": Yes,
+			"smb ports":       strconv.Itoa(opts.SmbPort),
 		},
 	}
 

--- a/main.go
+++ b/main.go
@@ -72,6 +72,13 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 
+	setupLog.Info("Initializing Manager",
+		"ProgramName", os.Args[0],
+		"Version", Version,
+		"CommitID", CommitID,
+		"GoVersion", goruntime.Version(),
+	)
+
 	if err := conf.Load(confSource); err != nil {
 		setupLog.Error(err, "unable to configure")
 		os.Exit(1)
@@ -125,11 +132,7 @@ func main() {
 	}
 	// +kubebuilder:scaffold:builder
 
-	setupLog.Info("starting manager",
-		"Version", Version,
-		"CommitID", CommitID,
-		"GoVersion", goruntime.Version(),
-	)
+	setupLog.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -83,10 +83,12 @@ func main() {
 		setupLog.Error(err, "unable to configure")
 		os.Exit(1)
 	}
+
 	if err := conf.Get().Validate(); err != nil {
-		setupLog.Error(err, "invalid configuration")
+		setupLog.Error(err, "invalid configuration", "config", conf.Get())
 		os.Exit(1)
 	}
+	setupLog.Info("loaded configuration successfully", "config", conf.Get())
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:             scheme,


### PR DESCRIPTION
Enable deployment on OpenShift cluster, where smbd container can not run with UID=0, and can not bind to privileged ports. Pass explicit service and ambd ports via operator-config.

Tested over OpenShift 4.9