### PR TITLE
hack: bump kustomize version to v4.5.2

### DIFF
--- a/hack/install-tools.sh
+++ b/hack/install-tools.sh
@@ -12,20 +12,12 @@ _require_gobin() {
 	mkdir -p "${GOBIN}"
 }
 
-_install_kustomize() {
-	curdir="$(pwd)"
-	tmpdir="$(mktemp -d)"
-
-	mkdir -p "${tmpdir}"
-	cd "${tmpdir}"
-	${GO_CMD} get sigs.k8s.io/kustomize/kustomize/v4@v4.3.0
-	cd "${curdir}"
-	find "${tmpdir}" -type d -exec chmod 700 {} \;
-	rm -rf "${tmpdir}"
-}
-
 _install_tool() {
 	GOBIN="${GOBIN}" ${GO_CMD} install "$1"
+}
+
+_install_kustomize() {
+	_install_tool sigs.k8s.io/kustomize/kustomize/v4@v4.5.2
 }
 
 _install_controller_gen() {


### PR DESCRIPTION
Latest stable version of kustomize fixes previous issues which prevented
from installing of 'kustomize' helper build-tool via 'go install'. Using
newer version we no longer need to use 'go get' in temporary directory,
and for users of go1.17 there isn't any deprecation notice.

Signed-off-by: Shachar Sharon <ssharon@redhat.com>