### PR TITLE
resouces: Add readinessProbe for ctdb container

### DIFF
--- a/internal/resources/planner.go
+++ b/internal/resources/planner.go
@@ -421,6 +421,14 @@ func (*sharePlanner) ctdbMustHaveNodeArgs() []string {
 	}
 }
 
+func (*sharePlanner) ctdbReadinessProbeArgs() []string {
+	return []string{
+		"samba-container",
+		"check",
+		"ctdb-nodestatus",
+	}
+}
+
 func (sp *sharePlanner) serviceType() string {
 	if sp.CommonConfig != nil && sp.CommonConfig.Spec.Network.Publish == "external" {
 		return "LoadBalancer"

--- a/internal/resources/pods.go
+++ b/internal/resources/pods.go
@@ -491,6 +491,13 @@ func buildCTDBDaemonCtr(
 		Args:         planner.ctdbDaemonArgs(),
 		Env:          env,
 		VolumeMounts: getMounts(vols),
+		ReadinessProbe: &corev1.Probe{
+			Handler: corev1.Handler{
+				Exec: &corev1.ExecAction{
+					Command: planner.ctdbReadinessProbeArgs(),
+				},
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
Use
samba-container check ctdb-nodestatus
as readiness probe for the ctdb container.

Signed-off-by: Sachin Prabhu <sprabhu@redhat.com>