### PR TITLE
Add Spec.Storage.Pvc.Path to design doc

### DIFF
--- a/docs/design/crd-proposal-phase1.md
+++ b/docs/design/crd-proposal-phase1.md
@@ -103,6 +103,7 @@ Spec Options:
         * `spec` - mapping, embedded pvc spec - An embedded PVC spec that will
           be used to dynamically create a backing PVC for the share; sharing
           the life-cycle of the PVC with the share
+        * `path` - string - The path within the PVC which should be exported.
     * TBD - Any other more custom storage back-ends if needed
 * `securityConfig` - string - The name of the SmbSecurityConfig CR associated
   with this share


### PR DESCRIPTION
The Spec.Storage.Pvc.Path allows the use of a path within the PVC.

Signed-off-by: Sachin Prabhu <sprabhu@redhat.com>