### PR TITLE
Few cleanup fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ endif
 GOARCH?=$(shell $(GO_CMD) env GOARCH)
 
 # Local (alternative) GOBIN for auxiliary build tools
-GOBIN_ALT:=$(CURDIR)/.bin/
+GOBIN_ALT:=$(CURDIR)/.bin
 
 
 CONTAINER_BUILD_OPTS?=

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -7,7 +7,7 @@ namePrefix: samba-operator-
 # Labels to add to all resources and selectors.
 #commonLabels:
 #  someName: someValue
-bases:
+resources:
   - ../crd
   - ../rbac
   - ../manager-full

--- a/config/manager-full/kustomization.yaml
+++ b/config/manager-full/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
+resources:
   - ../manager
 patchesStrategicMerge:
   # Protect the /metrics endpoint by putting it behind auth.


### PR DESCRIPTION
* Removes an extra forward slash **_/_**
* Replace **_bases_** with **_resources_** for _kustomize_. **_bases_** field was [deprecated](https://kubectl.docs.kubernetes.io/blog/2019/06/18/v2.1.0/#resources-expanded-bases-deprecated) long time back in favour of **_resources_**.