### PR TITLE
integration tests: Increase timeout for cleanup tests

### DIFF
--- a/tests/integration/cleanup_test.go
+++ b/tests/integration/cleanup_test.go
@@ -83,7 +83,7 @@ func (s *ShareCreateDeleteSuite) getPodFetchOptions() kube.PodFetchOptions {
 func (s *ShareCreateDeleteSuite) waitForNoSmbServices() error {
 	ctx, cancel := context.WithDeadline(
 		context.TODO(),
-		time.Now().Add(60*time.Second))
+		time.Now().Add(waitForPodsTime))
 	defer cancel()
 	err := poll.TryUntil(ctx, &poll.Prober{
 		Cond: func() (bool, error) {
@@ -165,7 +165,7 @@ func (s *ShareCreateDeleteSuite) TestCreateAndDelete() {
 
 	ctx, cancel := context.WithDeadline(
 		context.TODO(),
-		time.Now().Add(60*time.Second))
+		time.Now().Add(waitForPodsTime))
 	defer cancel()
 
 	// remove smbshare
@@ -197,7 +197,7 @@ func (s *ShareCreateDeleteSuite) TestCreateAndDelete() {
 	require.NoError(err)
 
 	deleteFromFiles(require, s.tc, s.fileSources)
-	time.Sleep(200 * time.Millisecond)
+	time.Sleep(waitForClearTime)
 
 	rs2 := s.getCurrentResources()
 	require.Equal(len(rs2.pods.Items), len(existing.pods.Items))

--- a/tests/integration/util_test.go
+++ b/tests/integration/util_test.go
@@ -10,8 +10,9 @@ import (
 )
 
 var (
-	waitForPodsTime  = 60 * time.Second
+	waitForPodsTime  = 120 * time.Second
 	waitForReadyTime = 200 * time.Second
+	waitForClearTime = 200 * time.Millisecond
 )
 
 type checker interface {


### PR DESCRIPTION
When testing clustered create and delete, the pods are created
serially and take much longer to come up causing test failures.

Increase the timeout for these tests to take into account the
time required to bring up the cluster. We also reuse timeout variables
in the create-delete tests.

Signed-off-by: Sachin Prabhu <sprabhu@redhat.com>