### PR TITLE
Raise overall test timeout while running with clustered test cases

### DIFF
--- a/tests/test.sh
+++ b/tests/test.sh
@@ -4,7 +4,11 @@ set -e
 cd "$(dirname "${0}")/.."
 
 gtest() {
-    go test -tags integration -v -count 1 "$@"
+    if [ "$SMBOP_TEST_CLUSTERED" ]; then
+        go test -tags integration -v -count 1 -timeout 20m "$@"
+    else
+        go test -tags integration -v -count 1 "$@"
+    fi
 }
 
 if [ "$SMBOP_TEST_RUN" ]; then


### PR DESCRIPTION
Clustered test cases brings in additional delay while waiting for pods to be ready. This contributes to increased overall test time which is not guaranteed to finish within default 10m timeout. Therefore raising the time limit for clustered test cases.