### PR TITLE
Prometheus metrics exporter for samba-operator

### DIFF
--- a/Dockerfile.smbmetrics
+++ b/Dockerfile.smbmetrics
@@ -1,0 +1,29 @@
+# Build smbmetrics
+FROM docker.io/golang:1.17 as builder
+ARG GIT_VERSION="(unset)"
+ARG COMMIT_ID="(unset)"
+ARG ARCH=""
+
+WORKDIR /workspace
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
+# Copy the go source
+COPY cmd/smbmetrics/main.go cmd/smbmetrics/main.go
+COPY internal/metrics internal/metrics
+
+# Build
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} GO111MODULE=on \
+    go build -a \
+    -ldflags "-X main.Version=${GIT_VERSION} -X main.CommitID=${COMMIT_ID}" \
+    -o smbmetrics cmd/smbmetrics/main.go
+
+# Use samba-server (with its smb.conf and samba utils) as base image
+FROM quay.io/samba.org/samba-server
+COPY --from=builder /workspace/smbmetrics /bin/smbmetrics
+
+ENTRYPOINT ["/bin/smbmetrics"]

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,9 @@ GOARCH?=$(shell $(GO_CMD) env GOARCH)
 # Local (alternative) GOBIN for auxiliary build tools
 GOBIN_ALT:=$(CURDIR)/.bin
 
+# Common link-flags for go programs
+GOLDFLAGS="-X main.Version=$(GIT_VERSION) -X main.CommitID=$(COMMIT_ID)"
+
 
 CONTAINER_BUILD_OPTS?=
 CONTAINER_CMD?=
@@ -96,7 +99,10 @@ coverage.html: cover.out
 manager: generate build vet
 
 build:
-	CGO_ENABLED=0 $(GO_CMD) build -o bin/manager -ldflags "-X main.Version=$(GIT_VERSION) -X main.CommitID=$(COMMIT_ID)"  main.go
+	CGO_ENABLED=0 $(GO_CMD) build -o bin/manager \
+		-ldflags $(GOLDFLAGS) main.go
+	CGO_ENABLED=0 $(GO_CMD) build -o bin/smbmetrics \
+		-ldflags $(GOLDFLAGS) cmd/smbmetrics/main.go
 .PHONY: build
 
 build-integration-tests:

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ YAMLLINT_CMD:=yamllint
 # Image URL to use all building/pushing image targets
 TAG?=latest
 IMG?=quay.io/samba.org/samba-operator:$(TAG)
+IMG_METRICS?=quay.io/samba.org/samba-metrics:$(TAG)
 
 # Produce CRDs that work on Kubernetes 1.16 or later
 CRD_OPTIONS?="crd:trivialVersions=true,crdVersions=v1"
@@ -184,6 +185,13 @@ image-build:
 		--build-arg=COMMIT_ID="$(COMMIT_ID)" \
 		--build-arg=ARCH="$(GOARCH)" \
 		$(CONTAINER_BUILD_OPTS) . -t $(IMG)
+
+image-metrics-build: Dockerfile.smbmetrics
+	$(CONTAINER_CMD) build \
+		--build-arg=GIT_VERSION="$(GIT_VERSION)" \
+		--build-arg=COMMIT_ID="$(COMMIT_ID)" \
+		--build-arg=ARCH="$(GOARCH)" \
+		$(CONTAINER_BUILD_OPTS) -f $< -t $(IMG_METRICS)
 
 .PHONY: image-build-buildah
 image-build-buildah: build

--- a/cmd/smbmetrics/main.go
+++ b/cmd/smbmetrics/main.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"os"
+	goruntime "runtime"
+
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/samba-in-kubernetes/samba-operator/internal/metrics"
+)
+
+var (
+	// Version of the software at compile time.
+	Version = "(unset)"
+	// CommitID of the revision used to compile the software.
+	CommitID = "(unset)"
+)
+
+func main() {
+	log := zap.New(zap.UseDevMode(true))
+	log.Info("Initializing smbmetrics",
+		"ProgramName", os.Args[0],
+		"Version", Version,
+		"CommitID", CommitID,
+		"GoVersion", goruntime.Version())
+
+	loc, err := metrics.LocateSmbStatus()
+	if err != nil {
+		log.Error(err, "Failed to locate smbstatus")
+		os.Exit(1)
+	}
+	ver, err := metrics.RunSmbStatusVersion()
+	if err != nil {
+		log.Error(err, "Failed to run smbstatus")
+		os.Exit(1)
+	}
+	log.Info("Located smbstatus", "path", loc, "version", ver)
+
+	err = metrics.RunSmbMetricsExporter(log)
+	if err != nil {
+		os.Exit(1)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/go-logr/logr v0.4.0
+	github.com/prometheus/client_golang v1.11.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.7.0

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -10,16 +10,18 @@ import (
 
 // DefaultOperatorConfig holds the default values of OperatorConfig.
 var DefaultOperatorConfig = OperatorConfig{
-	SmbdContainerImage:     "quay.io/samba.org/samba-server:latest",
-	SvcWatchContainerImage: "quay.io/samba.org/svcwatch:latest",
-	SmbdContainerName:      "samba",
-	WinbindContainerName:   "wb",
-	WorkingNamespace:       "",
-	SambaDebugLevel:        "",
-	StatePVCSize:           "1Gi",
-	ClusterSupport:         "",
-	SmbServicePort:         445,
-	SmbdPort:               445,
+	SmbdContainerImage:        "quay.io/samba.org/samba-server:latest",
+	SmbdMetricsContainerImage: "quay.io/samba.org/samba-metrics:latest",
+	SvcWatchContainerImage:    "quay.io/samba.org/svcwatch:latest",
+	SmbdContainerName:         "samba",
+	WinbindContainerName:      "wb",
+	WorkingNamespace:          "",
+	SambaDebugLevel:           "",
+	StatePVCSize:              "1Gi",
+	ClusterSupport:            "",
+	SmbServicePort:            445,
+	SmbdPort:                  445,
+	WithMetricsExporter:       false,
 }
 
 // OperatorConfig is a type holding general configuration values.
@@ -28,6 +30,9 @@ var DefaultOperatorConfig = OperatorConfig{
 type OperatorConfig struct {
 	// SmbdContainerImage can be used to select alternate container sources.
 	SmbdContainerImage string `mapstructure:"smbd-container-image"`
+	// SmbdMetricsContainerImage can be used to select alternate
+	// metrics-exporter container sources.
+	SmbdMetricsContainerImage string `mapstructure:"smbd-metrics-container-image"`
 	// SvcWatchContainerImage can be used to select alternate container image
 	// for the service watch utility.
 	SvcWatchContainerImage string `mapstructure:"svc-watch-container-image"`
@@ -58,6 +63,9 @@ type OperatorConfig struct {
 	// ServiceAccountName is a (string) which overrides the default service
 	// account associated with child pods. Required in OpenShift.
 	ServiceAccountName string `mapstructure:"service-account-name"`
+	// WithMetricsExporter is a (bool) flag which indicates if operator should
+	// run metrics-exporter container within samba-server pod.
+	WithMetricsExporter bool `mapstructure:"with-metrics-exporter"`
 }
 
 // Validate the OperatorConfig returning an error if the config is not
@@ -92,6 +100,7 @@ func NewSource() *Source {
 	d := DefaultOperatorConfig
 	v := viper.New()
 	v.SetDefault("smbd-container-image", d.SmbdContainerImage)
+	v.SetDefault("smbd-metrics-container-image", d.SmbdMetricsContainerImage)
 	v.SetDefault("smbd-container-name", d.SmbdContainerName)
 	v.SetDefault("winbind-container-name", d.WinbindContainerName)
 	v.SetDefault("working-namespace", d.WorkingNamespace)
@@ -102,6 +111,7 @@ func NewSource() *Source {
 	v.SetDefault("smb-service-port", d.SmbServicePort)
 	v.SetDefault("smbd-port", d.SmbdPort)
 	v.SetDefault("service-account-name", d.ServiceAccountName)
+	v.SetDefault("with-metrics-exporter", d.WithMetricsExporter)
 	return &Source{v: v}
 }
 

--- a/internal/metrics/collectors.go
+++ b/internal/metrics/collectors.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	collectorsNamespace = "smb"
+)
+
+func (sme *smbMetricsExporter) register() error {
+	cols := []prometheus.Collector{
+		sme.newSmbSharesCollector(),
+		sme.newSmbLocksCollector(),
+	}
+	for _, c := range cols {
+		if err := sme.reg.Register(c); err != nil {
+			sme.log.Error(err, "failed to register collector")
+			return err
+		}
+	}
+	return nil
+}
+
+type smbCollector struct {
+	// nolint:structcheck
+	sme *smbMetricsExporter
+	dsc []*prometheus.Desc
+}
+
+func (col *smbCollector) Describe(ch chan<- *prometheus.Desc) {
+	for _, d := range col.dsc {
+		ch <- d
+	}
+}
+
+type smbSharesCollector struct {
+	smbCollector
+}
+
+func (col *smbSharesCollector) Collect(ch chan<- prometheus.Metric) {
+	sharesTotal := 0
+	sharesMap, _ := SmbStatusSharesByMachine()
+	for machine, share := range sharesMap {
+		sharesCount := len(share)
+		ch <- prometheus.MustNewConstMetric(col.dsc[0],
+			prometheus.GaugeValue, float64(sharesCount), machine)
+		sharesTotal += sharesCount
+	}
+
+	ch <- prometheus.MustNewConstMetric(col.dsc[1],
+		prometheus.GaugeValue, float64(sharesTotal))
+}
+
+func (sme *smbMetricsExporter) newSmbSharesCollector() prometheus.Collector {
+	col := &smbSharesCollector{}
+	col.sme = sme
+	col.dsc = []*prometheus.Desc{
+		prometheus.NewDesc(
+			collectorName("shares", "machine"),
+			"Number of shares by host-machine ip",
+			[]string{"machine"}, nil),
+
+		prometheus.NewDesc(
+			collectorName("shares", "total"),
+			"Total number of active shares",
+			[]string{}, nil),
+	}
+	return col
+}
+
+type smbLocksCollector struct {
+	smbCollector
+}
+
+func (col *smbLocksCollector) Collect(ch chan<- prometheus.Metric) {
+	locks, _ := RunSmbStatusLocks()
+	ch <- prometheus.MustNewConstMetric(col.dsc[0],
+		prometheus.GaugeValue, float64(len(locks)))
+}
+
+func (sme *smbMetricsExporter) newSmbLocksCollector() prometheus.Collector {
+	col := &smbLocksCollector{}
+	col.sme = sme
+	col.dsc = []*prometheus.Desc{
+		prometheus.NewDesc(
+			collectorName("locks", "total"),
+			"Total number of active locks",
+			[]string{}, nil),
+	}
+	return col
+}
+
+func collectorName(subsystem, name string) string {
+	return prometheus.BuildFQName(collectorsNamespace, subsystem, name)
+}

--- a/internal/metrics/exporter.go
+++ b/internal/metrics/exporter.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+
+	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+var (
+	// DefaultMetricsPort is the default port used to export prometheus metrics
+	DefaultMetricsPort = int(8080)
+	// DefaultMetricsPath is the default HTTP path to export prometheus metrics
+	DefaultMetricsPath = "/metrics"
+)
+
+type smbMetricsExporter struct {
+	log  logr.Logger
+	reg  *prometheus.Registry
+	mux  *http.ServeMux
+	port int
+}
+
+func newSmbMetricsExporter(log logr.Logger, port int) *smbMetricsExporter {
+	return &smbMetricsExporter{
+		log:  log,
+		reg:  prometheus.NewRegistry(),
+		mux:  http.NewServeMux(),
+		port: port,
+	}
+}
+
+func (sme *smbMetricsExporter) init() error {
+	sme.log.Info("register collectors")
+	return sme.register()
+}
+
+func (sme *smbMetricsExporter) serve() error {
+	addr := fmt.Sprintf(":%d", sme.port)
+	sme.log.Info("serve metrics", "addr", addr)
+
+	handler := promhttp.HandlerFor(sme.reg, promhttp.HandlerOpts{})
+	sme.mux.Handle(DefaultMetricsPath, handler)
+
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		sme.log.Error(err, "failed to listen", "addr", addr)
+		return err
+	}
+	defer listener.Close()
+
+	if err := http.Serve(listener, sme.mux); err != nil {
+		sme.log.Error(err, "HTTP server failure", "addr", addr)
+		return err
+	}
+	return nil
+}
+
+// RunSmbMetricsExporter executes an HTTP server and exports SMB metrics to
+// Prometheus.
+func RunSmbMetricsExporter(log logr.Logger) error {
+	sme := newSmbMetricsExporter(log, DefaultMetricsPort)
+	err := sme.init()
+	if err != nil {
+		return err
+	}
+	return sme.serve()
+}

--- a/internal/metrics/pods.go
+++ b/internal/metrics/pods.go
@@ -1,0 +1,51 @@
+package metrics
+
+import (
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// AnnotationsForSmbMetricsPod returns the default annotation which are
+// required on the pod which executes the smbmetrics container, in order for
+// Prometheus to scrape it.
+func AnnotationsForSmbMetricsPod() map[string]string {
+	return map[string]string{
+		"prometheus.io/scrape": "true",
+		"prometheus.io/port":   strconv.Itoa(DefaultMetricsPort),
+		"prometheus.io/path":   DefaultMetricsPath,
+	}
+}
+
+// BuildSmbMetricsContainer returns the appropriate Container definition for
+// smbmetrics exporter.
+func BuildSmbMetricsContainer(image string,
+	volmnts []corev1.VolumeMount) corev1.Container {
+	portnum := DefaultMetricsPort
+	return corev1.Container{
+		// ImagePullPolicy: corev1.PullAlways,
+		Image:   image,
+		Name:    "samba-metrics",
+		Command: []string{"/bin/smbmetrics"},
+		Ports: []corev1.ContainerPort{{
+			ContainerPort: int32(portnum),
+			Name:          "smbmetrics",
+		}},
+		VolumeMounts: volmnts,
+		ReadinessProbe: &corev1.Probe{
+			Handler: corev1.Handler{
+				TCPSocket: &corev1.TCPSocketAction{
+					Port: intstr.FromInt(portnum),
+				},
+			},
+		},
+		LivenessProbe: &corev1.Probe{
+			Handler: corev1.Handler{
+				TCPSocket: &corev1.TCPSocketAction{
+					Port: intstr.FromInt(portnum),
+				},
+			},
+		},
+	}
+}

--- a/internal/metrics/smbstatus.go
+++ b/internal/metrics/smbstatus.go
@@ -1,0 +1,353 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// SmbStatusShare represents a single entry from the output of 'smbstatus -S'
+type SmbStatusShare struct {
+	Service       string
+	PID           int64
+	Machine       string
+	ConnectedAt   string
+	ConnectedTime time.Time
+	Encryption    string
+	Signing       string
+}
+
+// SmbStatusProc represents a single entry from the output of 'smbstatus -p'
+type SmbStatusProc struct {
+	PID             int64
+	Username        string
+	Group           string
+	Machine         string
+	ProtocolVersion string
+	Encryption      string
+	Signing         string
+}
+
+// SmbStatusLock represents a single entry from the output of 'smbstatus -L'
+type SmbStatusLock struct {
+	PID       int64
+	UserID    int64
+	DenyMode  string
+	Access    string
+	RW        string
+	Oplock    string
+	SharePath string
+	Name      string
+	Time      string
+}
+
+// LocateSmbStatus finds the local executable of 'smbstatus' on host container.
+func LocateSmbStatus() (string, error) {
+	knowns := []string{
+		"/usr/bin/smbstatus",
+	}
+	for _, loc := range knowns {
+		fi, err := os.Stat(loc)
+		if err != nil {
+			continue
+		}
+		mode := fi.Mode()
+		if !mode.IsRegular() {
+			continue
+		}
+		if (mode & 0111) > 0 {
+			return loc, nil
+		}
+	}
+	return "", errors.New("failed to locate smbstatus")
+}
+
+// RunSmbStatusVersion executes 'smbstatus --version' on host container
+func RunSmbStatusVersion() (string, error) {
+	ver, err := executeSmbStatusCommand("--version")
+	if err != nil {
+		return "", err
+	}
+	return ver, nil
+}
+
+// RunSmbStatusShares executes 'smbstatus -S' on host container
+func RunSmbStatusShares() ([]SmbStatusShare, error) {
+	dat, err := executeSmbStatusCommand("-S")
+	if err != nil {
+		return []SmbStatusShare{}, err
+	}
+	return parseSmbStatusShares(dat)
+}
+
+// RunSmbStatusLocks executes 'smbstatus -L' on host container
+func RunSmbStatusLocks() ([]SmbStatusLock, error) {
+	dat, err := executeSmbStatusCommand("-L")
+	if err != nil {
+		return []SmbStatusLock{}, err
+	}
+	return parseSmbStatusLocks(dat)
+}
+
+// RunSmbStatusProcs executes 'smbstatus -p' on host container
+func RunSmbStatusProcs() ([]SmbStatusProc, error) {
+	dat, err := executeSmbStatusCommand("-p")
+	if err != nil {
+		return []SmbStatusProc{}, err
+	}
+	return parseSmbStatusProcs(dat)
+}
+
+// SmbStatusSharesByMachine converts the output of RunSmbStatusShares into map
+// indexed by machine's host
+func SmbStatusSharesByMachine() (map[string][]SmbStatusShare, error) {
+	ret := map[string][]SmbStatusShare{}
+	shares, err := RunSmbStatusShares()
+	if err != nil {
+		return ret, err
+	}
+	for _, share := range shares {
+		ret[share.Machine] = append(ret[share.Machine], share)
+	}
+	return ret, nil
+}
+
+func executeSmbStatusCommand(args ...string) (string, error) {
+	loc, err := LocateSmbStatus()
+	if err != nil {
+		return "", err
+	}
+	return executeCommand(loc, args...)
+}
+
+func executeCommand(command string, arg ...string) (string, error) {
+	cmd := exec.Command(command, arg...)
+	out, err := cmd.Output()
+	if err != nil {
+		return string(out), err
+	}
+	res := strings.TrimSpace(string(out))
+	return res, nil
+}
+
+// parseSmbStatusShares parses to output of 'smbstatus -S' into internal
+// representation.
+func parseSmbStatusShares(data string) ([]SmbStatusShare, error) {
+	shares := []SmbStatusShare{}
+	serviceIndex := 0
+	pidIndex := 0
+	machineIndex := 0
+	connectedAtIndex := 0
+	encryptionIndex := 0
+	signingIndex := 0
+	hasDashLine := false
+	lines := strings.Split(data, "\n")
+	for _, line := range lines {
+		ln := strings.TrimSpace(line)
+		// Ignore empty and coment lines
+		if len(ln) == 0 || ln[0] == '#' {
+			continue
+		}
+		// Detect the all-dash line
+		if strings.HasPrefix(ln, "------") {
+			hasDashLine = true
+			continue
+		}
+		// Parse header line into index of data
+		if strings.HasPrefix(ln, "Service") {
+			serviceIndex = strings.Index(ln, "Service")
+			pidIndex = strings.Index(ln, "pid")
+			machineIndex = strings.Index(ln, "Machine")
+			connectedAtIndex = strings.Index(ln, "Connected at")
+			encryptionIndex = strings.Index(ln, "Encryption")
+			signingIndex = strings.Index(ln, "Signing")
+			continue
+		}
+		// Ignore lines before header
+		if !hasDashLine {
+			continue
+		}
+		// Parse data into internal repr
+		share := SmbStatusShare{}
+		share.Service = parseSubstr(ln, serviceIndex)
+		pid, err := parseInt64(ln, pidIndex)
+		if err != nil {
+			return shares, err
+		}
+		share.PID = pid
+		share.Machine = parseSubstr(ln, machineIndex)
+		share.ConnectedAt = parseSubstr2(ln, connectedAtIndex, encryptionIndex)
+		share.Encryption = parseSubstr(ln, encryptionIndex)
+		share.Signing = parseSubstr(ln, signingIndex)
+		if t, err := parseTime(share.ConnectedAt); err == nil {
+			share.ConnectedTime = t
+		}
+
+		// Ignore "IPC$"
+		if share.Service == "IPC$" {
+			continue
+		}
+
+		shares = append(shares, share)
+	}
+	return shares, nil
+}
+
+// parseSmbStatusProcs parses to output of 'smbstatus -p' into internal
+// representation.
+func parseSmbStatusProcs(data string) ([]SmbStatusProc, error) {
+	procs := []SmbStatusProc{}
+	pidIndex := 0
+	usernameIndex := 0
+	groupIndex := 0
+	machineIndex := 0
+	protocolVersionIndex := 0
+	encryptionIndex := 0
+	signingIndex := 0
+	hasDashLine := false
+	lines := strings.Split(data, "\n")
+	for _, line := range lines {
+		ln := strings.TrimSpace(line)
+		// Ignore empty and coment lines
+		if len(ln) == 0 || ln[0] == '#' {
+			continue
+		}
+		// Detect the all-dash line
+		if strings.HasPrefix(ln, "------") {
+			hasDashLine = true
+			continue
+		}
+		// Parse header line into index of data
+		if strings.HasPrefix(ln, "PID") {
+			pidIndex = strings.Index(ln, "PID")
+			usernameIndex = strings.Index(ln, "Username")
+			groupIndex = strings.Index(ln, "Group")
+			machineIndex = strings.Index(ln, "Machine")
+			protocolVersionIndex = strings.Index(ln, "Protocol Version")
+			encryptionIndex = strings.Index(ln, "Encryption")
+			signingIndex = strings.Index(ln, "Signing")
+			continue
+		}
+		// Ignore lines before header
+		if !hasDashLine {
+			continue
+		}
+		// Parse data into internal repr
+		proc := SmbStatusProc{}
+		pid, err := parseInt64(ln, pidIndex)
+		if err != nil {
+			return procs, err
+		}
+		proc.PID = pid
+		proc.Username = parseSubstr(ln, usernameIndex)
+		proc.Group = parseSubstr(ln, groupIndex)
+		proc.Machine = parseSubstr(ln, machineIndex)
+		proc.ProtocolVersion = parseSubstr(ln, protocolVersionIndex)
+		proc.Encryption = parseSubstr(ln, encryptionIndex)
+		proc.Signing = parseSubstr(ln, signingIndex)
+		procs = append(procs, proc)
+	}
+	return procs, nil
+}
+
+// parseSmbStatusLocks parses to output of 'smbstatus -L' into internal
+// representation.
+func parseSmbStatusLocks(data string) ([]SmbStatusLock, error) {
+	locks := []SmbStatusLock{}
+	pidIndex := 0
+	userIndex := 0
+	denyModeIndex := 0
+	accessIndex := 0
+	rwIndex := 0
+	oplockIndex := 0
+	sharePathIndex := 0
+	hasDashLine := false
+	lines := strings.Split(data, "\n")
+	for _, line := range lines {
+		ln := strings.TrimSpace(line)
+		// Ignore empty and coment lines
+		if len(ln) == 0 || ln[0] == '#' {
+			continue
+		}
+		// Detect the all-dash line
+		if strings.HasPrefix(ln, "------") {
+			hasDashLine = true
+			continue
+		}
+		// Ignore generic-info line
+		if strings.HasPrefix(ln, "Locked files") {
+			continue
+		}
+		// Parse header line into index of data
+		if strings.HasPrefix(ln, "Pid") {
+			pidIndex = strings.Index(ln, "Pid")
+			userIndex = strings.Index(ln, "User")
+			denyModeIndex = strings.Index(ln, "DenyMode")
+			accessIndex = strings.Index(ln, "Access")
+			rwIndex = strings.Index(ln, "R/W")
+			oplockIndex = strings.Index(ln, "Oplock")
+			sharePathIndex = strings.Index(ln, "SharePath")
+			continue
+		}
+		// Ignore lines before header
+		if !hasDashLine {
+			continue
+		}
+		// Parse data into internal repr
+		lock := SmbStatusLock{}
+		pid, err := parseInt64(ln, pidIndex)
+		if err != nil {
+			return locks, err
+		}
+		lock.PID = pid
+		user, err := parseInt64(ln, userIndex)
+		if err != nil {
+			return locks, err
+		}
+		lock.UserID = user
+		lock.DenyMode = parseSubstr(ln, denyModeIndex)
+		lock.Access = parseSubstr(ln, accessIndex)
+		lock.RW = parseSubstr(ln, rwIndex)
+		lock.Oplock = parseSubstr(ln, oplockIndex)
+		lock.SharePath = parseSubstr(ln, sharePathIndex)
+		locks = append(locks, lock)
+	}
+	return locks, nil
+}
+
+func parseInt64(s string, startIndex int) (int64, error) {
+	return strconv.ParseInt(parseSubstr(s, startIndex), 10, 64)
+}
+
+func parseSubstr(s string, startIndex int) string {
+	sub := strings.TrimSpace(s[startIndex:])
+	fields := strings.Fields(sub)
+	if len(fields) == 0 {
+		return ""
+	}
+	return fields[0]
+}
+
+func parseSubstr2(s string, startIndex, endIndex int) string {
+	return strings.TrimSpace(s[startIndex:endIndex])
+}
+
+func parseTime(s string) (time.Time, error) {
+	layouts := []string{
+		time.ANSIC,
+		time.UnixDate,
+		time.RFC3339,
+	}
+	for _, layout := range layouts {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t, nil
+		}
+	}
+	// samba's lib/util/time.c uses non standad layout...
+	return time.Time{}, errors.New("unknow time format " + s)
+}

--- a/internal/metrics/smbstatus_test.go
+++ b/internal/metrics/smbstatus_test.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+//revive:disable line-length-limit
+//nolint:revive,lll
+var (
+	outputSmbStatusS = `
+
+	Service      pid     Machine       Connected at                     Encryption   Signing
+	----------------------------------------------------------------------------------------
+	share_test   13668   10.66.208.149 Wed Sep 27 10:33:55 AM 2017 CST  -            -
+	share_test2  13669   10.66.208.149 Wed Sep 27 10:35:56 AM 2022 CST  -            -
+	IPC$         651248  10.0.0.100    Sat Sep  4 10:37:01 AM 2020 MDT  -            -
+
+`
+
+	outputSmbStatusp = `
+
+Samba version 4.14.12
+PID     Username     Group        Machine                                   Protocol Version  Encryption           Signing
+----------------------------------------------------------------------------------------------------------------------------------------
+245     user         user         127.0.0.1 (ipv4:127.0.0.1:55106)          SMB3_11           -                    partial(AES-128-CMAC)
+9701    root         wheel        10.0.0.2 (ipv4:10.0.0.2:55107)            SMB3_12           -                    partial(AES-128-CMAC)
+
+`
+
+	outputSmbStatusL = `
+
+Locked files:
+Pid          User(ID)   DenyMode   Access      R/W        Oplock           SharePath   Name   Time
+--------------------------------------------------------------------------------------------------
+241          1001       DENY_NONE  0x120089    RDONLY     LEASE(RWH)       /mnt/514cd7ba-d858-4d3a-bed9-68e4e524493b   A/a   Mon Feb 21 13:07:46 2022
+
+`
+)
+
+//revive:enable line-length-limit
+
+func TestParseSmbStatusShares(t *testing.T) {
+	locks, err := parseSmbStatusShares(outputSmbStatusS)
+	assert.NoError(t, err)
+	assert.Equal(t, len(locks), 2)
+	lock1 := locks[0]
+	assert.Equal(t, lock1.Service, "share_test")
+	assert.Equal(t, lock1.PID, int64(13668))
+	assert.Equal(t, lock1.Machine, "10.66.208.149")
+	assert.Equal(t, lock1.Encryption, "-")
+	assert.Equal(t, lock1.Signing, "-")
+}
+
+func TestParseSmbStatusProcs(t *testing.T) {
+	procs, err := parseSmbStatusProcs(outputSmbStatusp)
+	assert.NoError(t, err)
+	assert.Equal(t, len(procs), 2)
+	proc1 := procs[0]
+	assert.Equal(t, proc1.PID, int64(245))
+	assert.Equal(t, proc1.Username, "user")
+	assert.Equal(t, proc1.Group, "user")
+	assert.Equal(t, proc1.ProtocolVersion, "SMB3_11")
+	proc2 := procs[1]
+	assert.Equal(t, proc2.PID, int64(9701))
+	assert.Equal(t, proc2.Username, "root")
+	assert.Equal(t, proc2.Group, "wheel")
+	assert.Equal(t, proc2.ProtocolVersion, "SMB3_12")
+}
+
+func TestParseSmbStatusLocks(t *testing.T) {
+	locks, err := parseSmbStatusLocks(outputSmbStatusL)
+	assert.NoError(t, err)
+	assert.Equal(t, len(locks), 1)
+	lock1 := locks[0]
+	assert.Equal(t, lock1.PID, int64(241))
+	assert.Equal(t, lock1.UserID, int64(1001))
+	assert.Equal(t, lock1.DenyMode, "DENY_NONE")
+	assert.Equal(t, lock1.RW, "RDONLY")
+}

--- a/internal/resources/pods.go
+++ b/internal/resources/pods.go
@@ -128,6 +128,9 @@ func buildUserPodSpec(
 	shareVol := shareVolumeAndMount(planner, pvcName)
 	vols = append(vols, shareVol)
 
+	stateVol := sambaStateVolumeAndMount(planner)
+	vols = append(vols, stateVol)
+
 	configVol := configVolumeAndMount(planner)
 	vols = append(vols, configVol)
 

--- a/internal/resources/statefulsets.go
+++ b/internal/resources/statefulsets.go
@@ -45,7 +45,7 @@ func buildStatefulSet(
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      labels,
-					Annotations: annotationsForSmbPod(planner.GlobalConfig.SmbdContainerName),
+					Annotations: annotationsForSmbPod(planner.GlobalConfig),
 				},
 				Spec: podSpec,
 			},


### PR DESCRIPTION
Provide Prometheus metrics-exporter container and deploy is along-side (i.e., within same pod as) the samba-server container. Use 'smbstatus' to query smbd and export it over HTTP port 8080.