### PR TITLE
Add support for Spec.Storage.Pvc.Path component

### DIFF
--- a/api/v1alpha1/smbshare_types.go
+++ b/api/v1alpha1/smbshare_types.go
@@ -86,6 +86,10 @@ type SmbSharePvcSpec struct {
 	// Behaves similar to the embedded PVC spec for pods.
 	// +optional
 	Spec *corev1.PersistentVolumeClaimSpec `json:"spec,omitempty"`
+
+	// Path within the PVC which should be exported.
+	// +optional
+	Path string `json:"path,omitempty"`
 }
 
 // SmbShareScalingSpec defines scaling parameters for a share.

--- a/api/v1alpha1/smbshare_types.go
+++ b/api/v1alpha1/smbshare_types.go
@@ -88,6 +88,7 @@ type SmbSharePvcSpec struct {
 	Spec *corev1.PersistentVolumeClaimSpec `json:"spec,omitempty"`
 
 	// Path within the PVC which should be exported.
+	// +kubebuilder:validation:Pattern=`^[^\/]+$`
 	// +optional
 	Path string `json:"path,omitempty"`
 }

--- a/config/crd/bases/samba-operator.samba.org_smbshares.yaml
+++ b/config/crd/bases/samba-operator.samba.org_smbshares.yaml
@@ -71,6 +71,10 @@ spec:
                         name:
                           description: Name of the PVC to use for the share.
                           type: string
+                        path:
+                          description: Path within the PVC which should be exported.
+                          pattern: ^[^\/]+$
+                          type: string
                         spec:
                           description: Spec defines a new, temporary, PVC to use for the share. Behaves similar to the embedded PVC spec for pods.
                           properties:

--- a/internal/planner/configuration.go
+++ b/internal/planner/configuration.go
@@ -101,6 +101,9 @@ func (pl *Planner) Update() (changed bool, err error) {
 		}
 		pl.ConfigState.Shares[shareKey] = share
 		changed = true
+	} else if share.Options["path"] != pl.Paths().Share() {
+		// Update path if changed
+		share.Options["path"] = pl.Paths().Share()
 	}
 	cfgKey := pl.instanceID()
 	cfg, found := pl.ConfigState.Configs[cfgKey]

--- a/internal/planner/paths.go
+++ b/internal/planner/paths.go
@@ -30,9 +30,18 @@ func (planner *Planner) Paths() *Paths {
 	return &Paths{planner}
 }
 
+// ShareMountPath returns the mount path.
+func (p *Paths) ShareMountPath() string {
+	return path.Join("/mnt", string(p.planner.SmbShare.UID))
+}
+
 // Share path.
 func (p *Paths) Share() string {
-	return path.Join("/mnt", string(p.planner.SmbShare.UID))
+	sharepath := p.planner.SmbShare.Spec.Storage.Pvc.Path
+	if sharepath != "" {
+		return path.Join(p.ShareMountPath(), "/", sharepath)
+	}
+	return p.ShareMountPath()
 }
 
 // ContainerConfigs returns a slice containing all configuration

--- a/internal/resources/volumes.go
+++ b/internal/resources/volumes.go
@@ -66,7 +66,7 @@ func shareVolumeAndMount(planner *pln.Planner, pvcName string) volMount {
 	}
 	// mount
 	vmnt.mount = corev1.VolumeMount{
-		MountPath: planner.Paths().Share(),
+		MountPath: planner.Paths().ShareMountPath(),
 		Name:      pvcVolName,
 	}
 	return vmnt

--- a/tests/files/smbsharepvc1.yaml
+++ b/tests/files/smbsharepvc1.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: samba-operator.samba.org/v1alpha1
+kind: SmbShare
+metadata:
+  name: tshare1-setup-pvc
+  labels:
+    app: samba-operator-test-smbshare-withpvc
+spec:
+  readOnly: false
+  browseable: false
+  securityConfig: sharesec1
+  storage:
+    pvc:
+      name: "userpvc"

--- a/tests/files/smbsharepvc2.yaml
+++ b/tests/files/smbsharepvc2.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: samba-operator.samba.org/v1alpha1
+kind: SmbShare
+metadata:
+  name: tshare1-pvc
+  labels:
+    app: samba-operator-test-smbshare-withpvc
+spec:
+  readOnly: false
+  browseable: false
+  securityConfig: sharesec1
+  storage:
+    pvc:
+      name: "userpvc"
+      path: "testmnt1"

--- a/tests/files/userpvc.yaml
+++ b/tests/files/userpvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: userpvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+  volumeMode: Filesystem

--- a/tests/integration/mount_path_test.go
+++ b/tests/integration/mount_path_test.go
@@ -1,0 +1,139 @@
+// +build integration
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/samba-in-kubernetes/samba-operator/tests/utils/kube"
+	"github.com/samba-in-kubernetes/samba-operator/tests/utils/smbclient"
+)
+
+type MountPathSuite struct {
+	suite.Suite
+
+	auths                   []smbclient.Auth
+	commonSources           []kube.FileSource
+	smbshareSetupSources    []kube.FileSource
+	smbshareSources         []kube.FileSource
+	smbShareSetupResource   types.NamespacedName
+	setupServerLabelPattern string
+	smbShareResource        types.NamespacedName
+	serverLabelPattern      string
+	tc                      *kube.TestClient
+}
+
+func (s *MountPathSuite) getPodIP(labelPattern string) (string, error) {
+	pods, err := s.tc.FetchPods(
+		context.TODO(),
+		kube.PodFetchOptions{
+			Namespace:     testNamespace,
+			LabelSelector: labelPattern,
+			MaxFound:      1,
+		})
+	if err != nil {
+		return "", err
+	}
+	for _, pod := range pods {
+		if kube.PodIsReady(&pod) {
+			return pod.Status.PodIP, nil
+		}
+	}
+	return "", fmt.Errorf("no pods ready when fetching IP")
+}
+
+func (s *MountPathSuite) waitForPods(labelPattern string) {
+	require := s.Require()
+	ctx, cancel := context.WithDeadline(
+		context.TODO(),
+		time.Now().Add(waitForPodsTime))
+	defer cancel()
+	opts := kube.PodFetchOptions{
+		Namespace:     testNamespace,
+		LabelSelector: labelPattern,
+	}
+	require.NoError(
+		kube.WaitForAnyPodExists(ctx, kube.NewTestClient(""), opts),
+		"pod does not exist",
+	)
+	require.NoError(
+		kube.WaitForAnyPodReady(ctx, kube.NewTestClient(""), opts),
+		"pod not ready",
+	)
+}
+
+func (s *MountPathSuite) SetupSuite() {
+	s.tc = kube.NewTestClient("")
+	require := s.Require()
+	createFromFiles(require, s.tc, append(s.commonSources, s.smbshareSetupSources...))
+	// ensure the smbserver test pod exists and is ready
+	s.waitForPods(s.setupServerLabelPattern)
+	serverIP, err := s.getPodIP(s.setupServerLabelPattern)
+	require.NoError(err)
+	share := smbclient.Share{
+		Host: smbclient.Host(serverIP),
+		Name: s.smbShareSetupResource.Name,
+	}
+
+	// Create folders over smbclient
+	smbclient := smbclient.MustPodExec(s.tc, testNamespace,
+		"smbclient", "client")
+	err = smbclient.CacheFlush(context.TODO())
+	require.NoError(err)
+	auth := s.auths[0]
+	cmds := []string{
+		"mkdir testmnt1",
+		"mkdir testmnt2",
+		"mkdir testmnt1/mnt1",
+		"mkdir testmnt2/mnt2",
+	}
+	err = smbclient.Command(
+		context.TODO(),
+		share,
+		auth,
+		cmds)
+	require.NoError(err)
+
+	// Delete the smbshare created
+	deleteFromFiles(require, s.tc, s.smbshareSetupSources)
+
+	// Create smbshare with Spec.Storage.PVC.Path specified
+	createFromFiles(require, s.tc, append(s.commonSources, s.smbshareSources...))
+	s.waitForPods(s.serverLabelPattern)
+}
+
+func (s *MountPathSuite) TearDownSuite() {
+	deleteFromFiles(s.Require(), s.tc, s.smbshareSetupSources)
+	deleteFromFiles(s.Require(), s.tc, s.smbshareSources)
+	deleteFromFiles(s.Require(), s.tc, s.commonSources)
+}
+
+func (s *MountPathSuite) TestMountPath() {
+	require := s.Require()
+
+	serverIP, err := s.getPodIP(s.serverLabelPattern)
+	require.NoError(err)
+	share := smbclient.Share{
+		Host: smbclient.Host(serverIP),
+		Name: s.smbShareResource.Name,
+	}
+
+	// Test if correct path mounted using smbclient
+	smbclient := smbclient.MustPodExec(s.tc, testNamespace,
+		"smbclient", "client")
+	err = smbclient.CacheFlush(context.TODO())
+	require.NoError(err)
+	auth := s.auths[0]
+	out, err := smbclient.CommandOutput(
+		context.TODO(),
+		share,
+		auth,
+		[]string{"ls"})
+	require.NoError(err)
+	require.Contains(string(out), "mnt1")
+}

--- a/tests/integration/smb_share_test.go
+++ b/tests/integration/smb_share_test.go
@@ -374,6 +374,45 @@ func allSmbShareSuites() map[string]suite.TestingSuite {
 		}},
 	}}
 
+	m["mountPath"] = &MountPathSuite{
+		auths: []smbclient.Auth{
+			{
+				Username: "sambauser",
+				Password: "1nsecurely",
+			},
+		},
+		commonSources: []kube.FileSource{
+			{
+				Path:      path.Join(testFilesDir, "userpvc.yaml"),
+				Namespace: testNamespace,
+			},
+			{
+				Path:      path.Join(testFilesDir, "userssecret1.yaml"),
+				Namespace: testNamespace,
+			},
+			{
+				Path:      path.Join(testFilesDir, "smbsecurityconfig1.yaml"),
+				Namespace: testNamespace,
+			},
+		},
+		smbshareSetupSources: []kube.FileSource{
+			{
+				Path:      path.Join(testFilesDir, "smbsharepvc1.yaml"),
+				Namespace: testNamespace,
+			},
+		},
+		smbshareSources: []kube.FileSource{
+			{
+				Path:      path.Join(testFilesDir, "smbsharepvc2.yaml"),
+				Namespace: testNamespace,
+			},
+		},
+		smbShareSetupResource:   types.NamespacedName{testNamespace, "tshare1-setup-pvc"},
+		setupServerLabelPattern: "samba-operator.samba.org/service=tshare1-setup-pvc",
+		smbShareResource:        types.NamespacedName{testNamespace, "tshare1-pvc"},
+		serverLabelPattern:      "samba-operator.samba.org/service=tshare1-pvc",
+	}
+
 	if testClusteredShares {
 		m["smbShareClustered1"] = &SmbShareSuite{
 			fileSources: []kube.FileSource{


### PR DESCRIPTION
This allows users to specify the path within a pvc which should be exported by samba. Includes an integration test which tests this new feature.