### PR TITLE
Improvements to integration tests

### DIFF
--- a/tests/integration/reconcile_test.go
+++ b/tests/integration/reconcile_test.go
@@ -205,10 +205,10 @@ func allReconcileSuites() map[string]suite.TestingSuite {
 				{
 					Path:       path.Join(testFilesDir, "smbshare_ctdb1.yaml"),
 					Namespace:  testNamespace,
-					NameSuffix: "-bk",
+					NameSuffix: "-soc",
 				},
 			},
-			smbShareResource: types.NamespacedName{testNamespace, "cshare1-bk"},
+			smbShareResource: types.NamespacedName{testNamespace, "cshare1-soc"},
 		}
 	}
 	return m

--- a/tests/integration/smb_share_test.go
+++ b/tests/integration/smb_share_test.go
@@ -203,7 +203,7 @@ func (s *SmbShareWithDNSSuite) TestShareAccessByDomainName() {
 	// test that the IP in ad dns matches the service
 	ctx, cancel := context.WithDeadline(
 		context.TODO(),
-		time.Now().Add(30*time.Second))
+		time.Now().Add(waitForIpTime))
 	defer cancel()
 	hc := dnsclient.MustPodExec(s.tc, testNamespace, "smbclient", "")
 	s.Require().NoError(poll.TryUntil(ctx, &poll.Prober{

--- a/tests/integration/util_test.go
+++ b/tests/integration/util_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 var (
+	waitForIpTime    = 120 * time.Second
 	waitForPodsTime  = 120 * time.Second
 	waitForReadyTime = 200 * time.Second
 	waitForClearTime = 200 * time.Millisecond


### PR DESCRIPTION
In the light of various integration test runs(on CentOS CI) over the last few days following changes are found to be valid for reliable execution of test cases.

* Wait longer for Domain - Service IP verification
* Use different suffix for _TestScaleoutCluster_ test