### PR TITLE
Metrics exporter container within smbd pod

### DIFF
--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -10,16 +10,18 @@ import (
 
 // DefaultOperatorConfig holds the default values of OperatorConfig.
 var DefaultOperatorConfig = OperatorConfig{
-	SmbdContainerImage:     "quay.io/samba.org/samba-server:latest",
-	SvcWatchContainerImage: "quay.io/samba.org/svcwatch:latest",
-	SmbdContainerName:      "samba",
-	WinbindContainerName:   "wb",
-	WorkingNamespace:       "",
-	SambaDebugLevel:        "",
-	StatePVCSize:           "1Gi",
-	ClusterSupport:         "",
-	SmbServicePort:         445,
-	SmbdPort:               445,
+	SmbdContainerImage:        "quay.io/samba.org/samba-server:latest",
+	SmbdMetricsContainerImage: "quay.io/samba.org/samba-metrics:latest",
+	SvcWatchContainerImage:    "quay.io/samba.org/svcwatch:latest",
+	SmbdContainerName:         "samba",
+	WinbindContainerName:      "wb",
+	WorkingNamespace:          "",
+	SambaDebugLevel:           "",
+	StatePVCSize:              "1Gi",
+	ClusterSupport:            "",
+	SmbServicePort:            445,
+	SmbdPort:                  445,
+	MetricsExporterMode:       "disabled",
 }
 
 // OperatorConfig is a type holding general configuration values.
@@ -28,6 +30,9 @@ var DefaultOperatorConfig = OperatorConfig{
 type OperatorConfig struct {
 	// SmbdContainerImage can be used to select alternate container sources.
 	SmbdContainerImage string `mapstructure:"smbd-container-image"`
+	// SmbdMetricsContainerImage can be used to select alternate
+	// metrics-exporter container sources.
+	SmbdMetricsContainerImage string `mapstructure:"smbd-metrics-container-image"`
 	// SvcWatchContainerImage can be used to select alternate container image
 	// for the service watch utility.
 	SvcWatchContainerImage string `mapstructure:"svc-watch-container-image"`
@@ -58,6 +63,10 @@ type OperatorConfig struct {
 	// ServiceAccountName is a (string) which overrides the default service
 	// account associated with child pods. Required in OpenShift.
 	ServiceAccountName string `mapstructure:"service-account-name"`
+	// MetricsExporterMode is a (string) flag which indicates if and how the
+	// operator should run metrics-exporter container within samba-server pod.
+	// Valid values are "enabled", "disabled" or empty string (default).
+	MetricsExporterMode string `mapstructure:"metrics-exporter-mode"`
 }
 
 // Validate the OperatorConfig returning an error if the config is not
@@ -92,6 +101,7 @@ func NewSource() *Source {
 	d := DefaultOperatorConfig
 	v := viper.New()
 	v.SetDefault("smbd-container-image", d.SmbdContainerImage)
+	v.SetDefault("smbd-metrics-container-image", d.SmbdMetricsContainerImage)
 	v.SetDefault("smbd-container-name", d.SmbdContainerName)
 	v.SetDefault("winbind-container-name", d.WinbindContainerName)
 	v.SetDefault("working-namespace", d.WorkingNamespace)
@@ -102,6 +112,7 @@ func NewSource() *Source {
 	v.SetDefault("smb-service-port", d.SmbServicePort)
 	v.SetDefault("smbd-port", d.SmbdPort)
 	v.SetDefault("service-account-name", d.ServiceAccountName)
+	v.SetDefault("metrics-exporter-mode", d.MetricsExporterMode)
 	return &Source{v: v}
 }
 

--- a/internal/resources/metrics.go
+++ b/internal/resources/metrics.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package resources
+
+import (
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+var (
+	// defaultMetricsPort is the default port used to export prometheus metrics
+	defaultMetricsPort = int(8080)
+	// defaultMetricsPath is the default HTTP path to export prometheus metrics
+	defaultMetricsPath = "/metrics"
+)
+
+// annotationsForSmbMetricsPod returns the default annotation which are
+// required on the pod which executes the smbmetrics container, in order for
+// Prometheus to scrape it.
+func annotationsForSmbMetricsPod() map[string]string {
+	return map[string]string{
+		"prometheus.io/scrape": "true",
+		"prometheus.io/port":   strconv.Itoa(defaultMetricsPort),
+		"prometheus.io/path":   defaultMetricsPath,
+	}
+}
+
+// buildSmbMetricsContainer returns the appropriate Container definition for
+// smbmetrics exporter.
+func buildSmbMetricsContainer(image string,
+	volmnts []corev1.VolumeMount) corev1.Container {
+	portnum := defaultMetricsPort
+	return corev1.Container{
+		Image:   image,
+		Name:    "samba-metrics",
+		Command: []string{"/bin/smbmetrics"},
+		Ports: []corev1.ContainerPort{{
+			ContainerPort: int32(portnum),
+			Name:          "smbmetrics",
+		}},
+		VolumeMounts: volmnts,
+		ReadinessProbe: &corev1.Probe{
+			Handler: corev1.Handler{
+				TCPSocket: &corev1.TCPSocketAction{
+					Port: intstr.FromInt(portnum),
+				},
+			},
+		},
+		LivenessProbe: &corev1.Probe{
+			Handler: corev1.Handler{
+				TCPSocket: &corev1.TCPSocketAction{
+					Port: intstr.FromInt(portnum),
+				},
+			},
+		},
+	}
+}

--- a/internal/resources/pods.go
+++ b/internal/resources/pods.go
@@ -130,6 +130,9 @@ func buildUserPodSpec(
 	shareVol := shareVolumeAndMount(planner, pvcName)
 	vols = append(vols, shareVol)
 
+	stateVol := sambaStateVolumeAndMount(planner)
+	vols = append(vols, stateVol)
+
 	configVol := configVolumeAndMount(planner)
 	vols = append(vols, configVol)
 

--- a/internal/resources/pods.go
+++ b/internal/resources/pods.go
@@ -90,10 +90,9 @@ func buildADPodSpec(
 		},
 	)
 
-	containers := []corev1.Container{
-		buildSmbdCtr(planner, podEnv, smbdVols),
-		buildWinbinddCtr(planner, podEnv, smbServerVols),
-	}
+	containers := buildSmbdCtrs(planner, podEnv, smbdVols)
+	containers = append(containers,
+		buildWinbinddCtr(planner, podEnv, smbServerVols))
 
 	if planner.DNSRegister() != pln.DNSRegisterNever {
 		watchVol := svcWatchVolumeAndMount(
@@ -146,9 +145,7 @@ func buildUserPodSpec(
 	podEnv := defaultPodEnv(planner)
 	podSpec := defaultPodSpec(planner)
 	podSpec.Volumes = getVolumes(vols)
-	podSpec.Containers = []corev1.Container{
-		buildSmbdCtr(planner, podEnv, vols),
-	}
+	podSpec.Containers = buildSmbdCtrs(planner, podEnv, vols)
 	return podSpec
 }
 
@@ -256,7 +253,7 @@ func buildClusteredUserPodSpec(
 	// smbd
 	containers = append(
 		containers,
-		buildSmbdCtr(planner, podEnv, volumes))
+		buildSmbdCtrs(planner, podEnv, volumes)...)
 
 	podSpec := defaultPodSpec(planner)
 	podSpec.Volumes = getVolumes(volumes)
@@ -398,7 +395,7 @@ func buildClusteredADPodSpec(
 	// smbd
 	containers = append(
 		containers,
-		buildSmbdCtr(planner, podEnv, volumes))
+		buildSmbdCtrs(planner, podEnv, volumes)...)
 
 	// dns-register containers
 	if planner.DNSRegister() != pln.DNSRegisterNever {
@@ -421,6 +418,19 @@ func buildClusteredADPodSpec(
 	podSpec.InitContainers = initContainers
 	podSpec.Containers = containers
 	return podSpec
+}
+
+func buildSmbdCtrs(
+	planner *pln.Planner,
+	env []corev1.EnvVar,
+	vols []volMount) []corev1.Container {
+	// ---
+	ctrs := []corev1.Container{}
+	ctrs = append(ctrs, buildSmbdCtr(planner, env, vols))
+	if withMetricsExporter(planner.GlobalConfig) {
+		ctrs = append(ctrs, buildSmbdMetricsCtr(planner, vols))
+	}
+	return ctrs
 }
 
 func buildSmbdCtr(
@@ -455,6 +465,14 @@ func buildSmbdCtr(
 			},
 		},
 	}
+}
+
+func buildSmbdMetricsCtr(
+	planner *pln.Planner,
+	vols []volMount) corev1.Container {
+	// ---
+	return buildSmbMetricsContainer(
+		planner.GlobalConfig.SmbdMetricsContainerImage, getMounts(vols))
 }
 
 func buildWinbinddCtr(

--- a/internal/resources/statefulsets.go
+++ b/internal/resources/statefulsets.go
@@ -47,7 +47,7 @@ func buildStatefulSet(
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      labels,
-					Annotations: annotationsForSmbPod(planner.GlobalConfig.SmbdContainerName),
+					Annotations: annotationsForSmbPod(planner.GlobalConfig),
 				},
 				Spec: podSpec,
 			},


### PR DESCRIPTION
Provide the mechanism to execute samba metrics exporter as container along side smbd, within same pod. 

The code of smbmetrics is now developed in a separate repository:
https://github.com/samba-in-kubernetes/smbmetrics