### PR TITLE
go.mod: bump to go version 1.16

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/samba-in-kubernetes/samba-operator
 
-go 1.13
+go 1.16
 
 require (
 	github.com/go-logr/logr v0.4.0


### PR DESCRIPTION
Newer go1.16 dates to 2021-02-16 where go1.13 dates to 2019-09-03.

See also Go releases at: https://go.dev/doc/devel/release

Signed-off-by: Shachar Sharon <ssharon@redhat.com>