### PR TITLE
planner: use 'pl' for Planner variable name

### DIFF
--- a/internal/planner/misc.go
+++ b/internal/planner/misc.go
@@ -32,18 +32,18 @@ type UserSecuritySource struct {
 
 // UserSecuritySource returns the UserSecuritySource type for the
 // particular instance.
-func (sp *Planner) UserSecuritySource() UserSecuritySource {
+func (pl *Planner) UserSecuritySource() UserSecuritySource {
 	s := UserSecuritySource{}
-	if sp.SecurityMode() != UserMode {
+	if pl.SecurityMode() != UserMode {
 		return s
 	}
-	if sp.SecurityConfig == nil || sp.SecurityConfig.Spec.Users == nil {
+	if pl.SecurityConfig == nil || pl.SecurityConfig.Spec.Users == nil {
 		return s
 	}
 	s.Configured = true
-	s.Namespace = sp.SecurityConfig.Namespace
-	s.Secret = sp.SecurityConfig.Spec.Users.Secret
-	s.Key = sp.SecurityConfig.Spec.Users.Key
+	s.Namespace = pl.SecurityConfig.Namespace
+	s.Secret = pl.SecurityConfig.Spec.Users.Secret
+	s.Key = pl.SecurityConfig.Spec.Users.Key
 	return s
 }
 
@@ -63,10 +63,10 @@ const (
 )
 
 // DNSRegister returns a DNSRegister type for this instance.
-func (sp *Planner) DNSRegister() DNSRegister {
+func (pl *Planner) DNSRegister() DNSRegister {
 	reg := DNSRegisterNever
-	if sp.SecurityMode() == ADMode && sp.SecurityConfig.Spec.DNS != nil {
-		reg = DNSRegister(sp.SecurityConfig.Spec.DNS.Register)
+	if pl.SecurityMode() == ADMode && pl.SecurityConfig.Spec.DNS != nil {
+		reg = DNSRegister(pl.SecurityConfig.Spec.DNS.Register)
 	}
 	switch reg {
 	// allowed values
@@ -82,8 +82,8 @@ func (sp *Planner) DNSRegister() DNSRegister {
 
 // ServiceType returns the value that should be used for a Service fronting
 // the SMB port for this instance.
-func (sp *Planner) ServiceType() string {
-	if sp.CommonConfig != nil && sp.CommonConfig.Spec.Network.Publish == "external" {
+func (pl *Planner) ServiceType() string {
+	if pl.CommonConfig != nil && pl.CommonConfig.Spec.Network.Publish == "external" {
 		return "LoadBalancer"
 	}
 	return "ClusterIP"
@@ -91,18 +91,18 @@ func (sp *Planner) ServiceType() string {
 
 // SambaContainerDebugLevel returns a string that can be passed to Samba
 // tools for debugging.
-func (sp *Planner) SambaContainerDebugLevel() string {
-	return sp.GlobalConfig.SambaDebugLevel
+func (pl *Planner) SambaContainerDebugLevel() string {
+	return pl.GlobalConfig.SambaDebugLevel
 }
 
 // MayCluster returns true if the operator is permitted to create clustered
 // instances.
-func (sp *Planner) MayCluster() bool {
-	return sp.GlobalConfig.ClusterSupport == "ctdb-is-experimental"
+func (pl *Planner) MayCluster() bool {
+	return pl.GlobalConfig.ClusterSupport == "ctdb-is-experimental"
 }
 
 // NodeSpread returns true if pods are required to be spread over multiple
 // nodes.
-func (sp *Planner) NodeSpread() bool {
-	return sp.SmbShare.Annotations[nodeSpreadKey] != nodeSpreadDisable
+func (pl *Planner) NodeSpread() bool {
+	return pl.SmbShare.Annotations[nodeSpreadKey] != nodeSpreadDisable
 }

--- a/internal/planner/properties.go
+++ b/internal/planner/properties.go
@@ -41,17 +41,17 @@ const (
 )
 
 // InstanceName returns the instance's name.
-func (sp *Planner) InstanceName() string {
+func (pl *Planner) InstanceName() string {
 	// for now, its the name of the Server Group
-	return sp.SmbShare.Status.ServerGroup
+	return pl.SmbShare.Status.ServerGroup
 }
 
 // SecurityMode returns the high level security mode to be used.
-func (sp *Planner) SecurityMode() SecurityMode {
-	if sp.SecurityConfig == nil {
+func (pl *Planner) SecurityMode() SecurityMode {
+	if pl.SecurityConfig == nil {
 		return UserMode
 	}
-	m := SecurityMode(sp.SecurityConfig.Spec.Mode)
+	m := SecurityMode(pl.SecurityConfig.Spec.Mode)
 	if m != UserMode && m != ADMode {
 		// this shouldn't normally be possible unless kube validation
 		// fails or is out of sync.
@@ -61,30 +61,30 @@ func (sp *Planner) SecurityMode() SecurityMode {
 }
 
 // Realm returns the name of the realm (domain).
-func (sp *Planner) Realm() string {
-	return strings.ToUpper(sp.SecurityConfig.Spec.Realm)
+func (pl *Planner) Realm() string {
+	return strings.ToUpper(pl.SecurityConfig.Spec.Realm)
 }
 
 // Workgroup returns the name of the workgroup. This may be automatically
 // derived from the realm.
-func (sp *Planner) Workgroup() string {
+func (pl *Planner) Workgroup() string {
 	// todo: this is a big hack. needs thought and cleanup
-	parts := strings.SplitN(sp.Realm(), ".", 2)
+	parts := strings.SplitN(pl.Realm(), ".", 2)
 	return parts[0]
 }
 
 // IsClustered returns true if the instance is configured for clustering.
-func (sp *Planner) IsClustered() bool {
-	if sp.SmbShare.Spec.Scaling == nil {
+func (pl *Planner) IsClustered() bool {
+	if pl.SmbShare.Spec.Scaling == nil {
 		return false
 	}
-	return sp.SmbShare.Spec.Scaling.AvailabilityMode == "clustered"
+	return pl.SmbShare.Spec.Scaling.AvailabilityMode == "clustered"
 }
 
 // ClusterSize returns the (minimum) size of the cluster.
-func (sp *Planner) ClusterSize() int32 {
-	if sp.SmbShare.Spec.Scaling == nil {
+func (pl *Planner) ClusterSize() int32 {
+	if pl.SmbShare.Spec.Scaling == nil {
 		return 1
 	}
-	return int32(sp.SmbShare.Spec.Scaling.MinClusterSize)
+	return int32(pl.SmbShare.Spec.Scaling.MinClusterSize)
 }


### PR DESCRIPTION
Use 'pl' for Planner variable, and avoid confusion to the naive reader
with the (now obsolete) 'sl' name.

Signed-off-by: Shachar Sharon <ssharon@redhat.com>