### PR TITLE
resources: add a volKeeper type for wrangling volumes

### DIFF
--- a/internal/resources/pods.go
+++ b/internal/resources/pods.go
@@ -121,32 +121,32 @@ func buildUserPodSpec(
 	_ *conf.OperatorConfig,
 	pvcName string) corev1.PodSpec {
 	// ---
-	vols := []volMount{}
+	vols := newVolKeeper()
 	initContainers := []corev1.Container{}
 
 	shareVol := shareVolumeAndMount(planner, pvcName)
-	vols = append(vols, shareVol)
+	vols.add(shareVol)
 
 	stateVol := sambaStateVolumeAndMount(planner)
-	vols = append(vols, stateVol)
+	vols.add(stateVol)
 
 	configVol := configVolumeAndMount(planner)
-	vols = append(vols, configVol)
+	vols.add(configVol)
 
 	podEnv := defaultPodEnv(planner)
 	initContainers = append(initContainers,
-		buildEnsureShareCtr(planner, podEnv, vols))
+		buildEnsureShareCtr(planner, podEnv, vols.all()))
 
 	osRunVol := osRunVolumeAndMount(planner)
-	vols = append(vols, osRunVol)
+	vols.add(osRunVol)
 
 	if planner.UserSecuritySource().Configured {
 		v := userConfigVolumeAndMount(planner)
-		vols = append(vols, v)
+		vols.add(v)
 	}
 	podSpec := defaultPodSpec(planner)
-	podSpec.Volumes = getVolumes(vols)
-	podSpec.Containers = buildSmbdCtrs(planner, podEnv, vols)
+	podSpec.Volumes = getVolumes(vols.all())
+	podSpec.Containers = buildSmbdCtrs(planner, podEnv, vols.all())
 	podSpec.InitContainers = initContainers
 	return podSpec
 }

--- a/internal/resources/pods.go
+++ b/internal/resources/pods.go
@@ -156,41 +156,41 @@ func buildClusteredUserPodSpec(
 	dataPVCName, statePVCName string) corev1.PodSpec {
 	// ---
 	var (
-		volumes        []volMount
-		podCfgVols     []volMount
+		volumes        = newVolKeeper()
+		podCfgVols     = newVolKeeper()
 		initContainers []corev1.Container
 		containers     []corev1.Container
 	)
 
 	shareVol := shareVolumeAndMount(planner, dataPVCName)
-	volumes = append(volumes, shareVol)
+	volumes.add(shareVol)
 
 	configVol := configVolumeAndMount(planner)
-	volumes = append(volumes, configVol)
-	podCfgVols = append(podCfgVols, configVol)
+	volumes.add(configVol)
+	podCfgVols.add(configVol)
 
 	stateVol := sambaStateVolumeAndMount(planner)
-	volumes = append(volumes, stateVol)
+	volumes.add(stateVol)
 
 	ctdbConfigVol := ctdbConfigVolumeAndMount(planner)
-	volumes = append(volumes, ctdbConfigVol)
+	volumes.add(ctdbConfigVol)
 
 	ctdbPeristentVol := ctdbPersistentVolumeAndMount(planner)
-	volumes = append(volumes, ctdbPeristentVol)
+	volumes.add(ctdbPeristentVol)
 
 	ctdbVolatileVol := ctdbVolatileVolumeAndMount(planner)
-	volumes = append(volumes, ctdbVolatileVol)
+	volumes.add(ctdbVolatileVol)
 
 	ctdbSocketsVol := ctdbSocketsVolumeAndMount(planner)
-	volumes = append(volumes, ctdbSocketsVol)
+	volumes.add(ctdbSocketsVol)
 
 	ctdbSharedVol := ctdbSharedStateVolumeAndMount(planner, statePVCName)
-	volumes = append(volumes, ctdbSharedVol)
+	volumes.add(ctdbSharedVol)
 
 	if planner.UserSecuritySource().Configured {
 		v := userConfigVolumeAndMount(planner)
-		volumes = append(volumes, v)
-		podCfgVols = append(podCfgVols, v)
+		volumes.add(v)
+		podCfgVols.add(v)
 	}
 
 	podEnv := defaultPodEnv(planner)
@@ -199,74 +199,66 @@ func buildClusteredUserPodSpec(
 
 	initContainers = append(
 		initContainers,
-		buildInitCtr(planner, podEnv, append(
-			podCfgVols,
-			stateVol,
-			ctdbSharedVol, // needed to decide if real init or not
-		)))
+		buildInitCtr(
+			planner,
+			podEnv,
+			// ctdbSharedVol is needed to decide if real init or not
+			podCfgVols.clone().add(stateVol).add(ctdbSharedVol).all(),
+		))
 
 	initContainers = append(
 		initContainers,
-		buildEnsureShareCtr(planner, podEnv, append(
-			podCfgVols,
-			stateVol,
-			shareVol,
-		)))
+		buildEnsureShareCtr(
+			planner,
+			podEnv,
+			podCfgVols.clone().add(stateVol).add(shareVol).all(),
+		))
 
+	ctdbMigrateVols := podCfgVols.clone().
+		add(stateVol).
+		add(ctdbSharedVol).
+		add(ctdbConfigVol).
+		add(ctdbPeristentVol)
 	initContainers = append(
 		initContainers,
-		buildCTDBMigrateCtr(planner, ctdbEnv, append(
-			podCfgVols,
-			stateVol,
-			ctdbSharedVol,
-			ctdbConfigVol,
-			ctdbPeristentVol,
-		)))
-
-	ctdbInitVols := dupVolMounts(podCfgVols)
-	ctdbInitVols = append(
-		ctdbInitVols,
-		stateVol,
-		ctdbSharedVol,
-		ctdbConfigVol,
+		buildCTDBMigrateCtr(planner, ctdbEnv, ctdbMigrateVols.all()),
 	)
+
+	ctdbInitVols := podCfgVols.clone().
+		add(stateVol).
+		add(ctdbSharedVol).
+		add(ctdbConfigVol)
 	initContainers = append(
 		initContainers,
-		buildCTDBSetNodeCtr(planner, ctdbEnv, ctdbInitVols),
-		buildCTDBMustHaveNodeCtr(planner, ctdbEnv, ctdbInitVols),
+		buildCTDBSetNodeCtr(planner, ctdbEnv, ctdbInitVols.all()),
+		buildCTDBMustHaveNodeCtr(planner, ctdbEnv, ctdbInitVols.all()),
 	)
 
-	ctdbdVols := dupVolMounts(podCfgVols)
-	ctdbdVols = append(
-		ctdbdVols,
-		ctdbConfigVol,
-		ctdbPeristentVol,
-		ctdbVolatileVol,
-		ctdbSocketsVol,
-		ctdbSharedVol,
-	)
+	ctdbdVols := podCfgVols.clone().
+		add(ctdbConfigVol).
+		add(ctdbPeristentVol).
+		add(ctdbVolatileVol).
+		add(ctdbSocketsVol).
+		add(ctdbSharedVol)
 	containers = append(
 		containers,
-		buildCTDBDaemonCtr(planner, ctdbEnv, ctdbdVols))
+		buildCTDBDaemonCtr(planner, ctdbEnv, ctdbdVols.all()))
 
-	ctdbManageNodesVols := dupVolMounts(podCfgVols)
-	ctdbManageNodesVols = append(
-		ctdbManageNodesVols,
-		ctdbConfigVol,
-		ctdbSocketsVol,
-		ctdbSharedVol,
-	)
+	ctdbManageNodesVols := podCfgVols.clone().
+		add(ctdbConfigVol).
+		add(ctdbSocketsVol).
+		add(ctdbSharedVol)
 	containers = append(
 		containers,
-		buildCTDBManageNodesCtr(planner, ctdbEnv, ctdbManageNodesVols))
+		buildCTDBManageNodesCtr(planner, ctdbEnv, ctdbManageNodesVols.all()))
 
 	// smbd
 	containers = append(
 		containers,
-		buildSmbdCtrs(planner, podEnv, volumes)...)
+		buildSmbdCtrs(planner, podEnv, volumes.all())...)
 
 	podSpec := defaultPodSpec(planner)
-	podSpec.Volumes = getVolumes(volumes)
+	podSpec.Volumes = getVolumes(volumes.all())
 	podSpec.InitContainers = initContainers
 	podSpec.Containers = containers
 	return podSpec

--- a/internal/resources/pods.go
+++ b/internal/resources/pods.go
@@ -427,7 +427,8 @@ func buildSmbdCtrs(
 	ctrs := []corev1.Container{}
 	ctrs = append(ctrs, buildSmbdCtr(planner, env, vols))
 	if withMetricsExporter(planner.GlobalConfig) {
-		ctrs = append(ctrs, buildSmbdMetricsCtr(planner, metaPodEnv(), vols))
+		mmVols := vols.exclude(tagData)
+		ctrs = append(ctrs, buildSmbdMetricsCtr(planner, metaPodEnv(), mmVols))
 	}
 	return ctrs
 }

--- a/internal/resources/pods.go
+++ b/internal/resources/pods.go
@@ -121,32 +121,32 @@ func buildUserPodSpec(
 	_ *conf.OperatorConfig,
 	pvcName string) corev1.PodSpec {
 	// ---
-	vols := newVolKeeper()
+	volumes := newVolKeeper()
 	initContainers := []corev1.Container{}
 
 	shareVol := shareVolumeAndMount(planner, pvcName)
-	vols.add(shareVol)
+	volumes.add(shareVol)
 
 	stateVol := sambaStateVolumeAndMount(planner)
-	vols.add(stateVol)
+	volumes.add(stateVol)
 
 	configVol := configVolumeAndMount(planner)
-	vols.add(configVol)
+	volumes.add(configVol)
 
 	podEnv := defaultPodEnv(planner)
 	initContainers = append(initContainers,
-		buildEnsureShareCtr(planner, podEnv, vols))
+		buildEnsureShareCtr(planner, podEnv, volumes))
 
 	osRunVol := osRunVolumeAndMount(planner)
-	vols.add(osRunVol)
+	volumes.add(osRunVol)
 
 	if planner.UserSecuritySource().Configured {
 		v := userConfigVolumeAndMount(planner)
-		vols.add(v)
+		volumes.add(v)
 	}
 	podSpec := defaultPodSpec(planner)
-	podSpec.Volumes = getVolumes(vols.all())
-	podSpec.Containers = buildSmbdCtrs(planner, podEnv, vols)
+	podSpec.Volumes = getVolumes(volumes.all())
+	podSpec.Containers = buildSmbdCtrs(planner, podEnv, volumes)
 	podSpec.InitContainers = initContainers
 	return podSpec
 }

--- a/internal/resources/pods.go
+++ b/internal/resources/pods.go
@@ -87,9 +87,9 @@ func buildADPodSpec(
 		},
 	)
 
-	containers := buildSmbdCtrs(planner, podEnv, smbdVols.all())
+	containers := buildSmbdCtrs(planner, podEnv, smbdVols)
 	containers = append(containers,
-		buildWinbinddCtr(planner, podEnv, smbServerVols.all()))
+		buildWinbinddCtr(planner, podEnv, smbServerVols))
 
 	if planner.DNSRegister() != pln.DNSRegisterNever {
 		watchVol := svcWatchVolumeAndMount(
@@ -100,17 +100,17 @@ func buildADPodSpec(
 		dnsRegVols := smbServerVols.clone().add(watchVol)
 		containers = append(
 			containers,
-			buildSvcWatchCtr(planner, svcWatchEnv(planner), svcWatchVols.all()),
-			buildDNSRegCtr(planner, podEnv, dnsRegVols.all()),
+			buildSvcWatchCtr(planner, svcWatchEnv(planner), svcWatchVols),
+			buildDNSRegCtr(planner, podEnv, dnsRegVols),
 		)
 	}
 
 	podSpec := defaultPodSpec(planner)
 	podSpec.Volumes = getVolumes(volumes.all())
 	podSpec.InitContainers = []corev1.Container{
-		buildInitCtr(planner, podEnv, smbAllVols.all()),
-		buildEnsureShareCtr(planner, podEnv, smbdVols.all()),
-		buildMustJoinCtr(planner, joinEnv, joinVols.all()),
+		buildInitCtr(planner, podEnv, smbAllVols),
+		buildEnsureShareCtr(planner, podEnv, smbdVols),
+		buildMustJoinCtr(planner, joinEnv, joinVols),
 	}
 	podSpec.Containers = containers
 	return podSpec
@@ -135,7 +135,7 @@ func buildUserPodSpec(
 
 	podEnv := defaultPodEnv(planner)
 	initContainers = append(initContainers,
-		buildEnsureShareCtr(planner, podEnv, vols.all()))
+		buildEnsureShareCtr(planner, podEnv, vols))
 
 	osRunVol := osRunVolumeAndMount(planner)
 	vols.add(osRunVol)
@@ -146,7 +146,7 @@ func buildUserPodSpec(
 	}
 	podSpec := defaultPodSpec(planner)
 	podSpec.Volumes = getVolumes(vols.all())
-	podSpec.Containers = buildSmbdCtrs(planner, podEnv, vols.all())
+	podSpec.Containers = buildSmbdCtrs(planner, podEnv, vols)
 	podSpec.InitContainers = initContainers
 	return podSpec
 }
@@ -203,7 +203,7 @@ func buildClusteredUserPodSpec(
 			planner,
 			podEnv,
 			// ctdbSharedVol is needed to decide if real init or not
-			podCfgVols.clone().add(stateVol).add(ctdbSharedVol).all(),
+			podCfgVols.clone().add(stateVol).add(ctdbSharedVol),
 		))
 
 	initContainers = append(
@@ -211,7 +211,7 @@ func buildClusteredUserPodSpec(
 		buildEnsureShareCtr(
 			planner,
 			podEnv,
-			podCfgVols.clone().add(stateVol).add(shareVol).all(),
+			podCfgVols.clone().add(stateVol).add(shareVol),
 		))
 
 	ctdbMigrateVols := podCfgVols.clone().
@@ -221,7 +221,7 @@ func buildClusteredUserPodSpec(
 		add(ctdbPeristentVol)
 	initContainers = append(
 		initContainers,
-		buildCTDBMigrateCtr(planner, ctdbEnv, ctdbMigrateVols.all()),
+		buildCTDBMigrateCtr(planner, ctdbEnv, ctdbMigrateVols),
 	)
 
 	ctdbInitVols := podCfgVols.clone().
@@ -230,8 +230,8 @@ func buildClusteredUserPodSpec(
 		add(ctdbConfigVol)
 	initContainers = append(
 		initContainers,
-		buildCTDBSetNodeCtr(planner, ctdbEnv, ctdbInitVols.all()),
-		buildCTDBMustHaveNodeCtr(planner, ctdbEnv, ctdbInitVols.all()),
+		buildCTDBSetNodeCtr(planner, ctdbEnv, ctdbInitVols),
+		buildCTDBMustHaveNodeCtr(planner, ctdbEnv, ctdbInitVols),
 	)
 
 	ctdbdVols := podCfgVols.clone().
@@ -242,7 +242,7 @@ func buildClusteredUserPodSpec(
 		add(ctdbSharedVol)
 	containers = append(
 		containers,
-		buildCTDBDaemonCtr(planner, ctdbEnv, ctdbdVols.all()))
+		buildCTDBDaemonCtr(planner, ctdbEnv, ctdbdVols))
 
 	ctdbManageNodesVols := podCfgVols.clone().
 		add(ctdbConfigVol).
@@ -250,12 +250,12 @@ func buildClusteredUserPodSpec(
 		add(ctdbSharedVol)
 	containers = append(
 		containers,
-		buildCTDBManageNodesCtr(planner, ctdbEnv, ctdbManageNodesVols.all()))
+		buildCTDBManageNodesCtr(planner, ctdbEnv, ctdbManageNodesVols))
 
 	// smbd
 	containers = append(
 		containers,
-		buildSmbdCtrs(planner, podEnv, volumes.all())...)
+		buildSmbdCtrs(planner, podEnv, volumes)...)
 
 	podSpec := defaultPodSpec(planner)
 	podSpec.Volumes = getVolumes(volumes.all())
@@ -321,7 +321,7 @@ func buildClusteredADPodSpec(
 			planner,
 			podEnv,
 			// ctdbSharedVol is needed to decide if real init or not
-			podCfgVols.clone().add(stateVol).add(ctdbSharedVol).all(),
+			podCfgVols.clone().add(stateVol).add(ctdbSharedVol),
 		))
 
 	initContainers = append(
@@ -329,7 +329,7 @@ func buildClusteredADPodSpec(
 		buildEnsureShareCtr(
 			planner,
 			podEnv,
-			podCfgVols.clone().add(stateVol).add(shareVol).all(),
+			podCfgVols.clone().add(stateVol).add(shareVol),
 		))
 
 	joinVols := podCfgVols.clone().
@@ -338,7 +338,7 @@ func buildClusteredADPodSpec(
 		extend(jsrc.volumes)
 	initContainers = append(
 		initContainers,
-		buildMustJoinCtr(planner, joinEnv, joinVols.all()),
+		buildMustJoinCtr(planner, joinEnv, joinVols),
 	)
 
 	ctdbMigrateVols := podCfgVols.clone().
@@ -348,7 +348,7 @@ func buildClusteredADPodSpec(
 		add(ctdbPeristentVol)
 	initContainers = append(
 		initContainers,
-		buildCTDBMigrateCtr(planner, ctdbEnv, ctdbMigrateVols.all()),
+		buildCTDBMigrateCtr(planner, ctdbEnv, ctdbMigrateVols),
 	)
 
 	ctdbInitVols := podCfgVols.clone().
@@ -357,8 +357,8 @@ func buildClusteredADPodSpec(
 		add(ctdbConfigVol)
 	initContainers = append(
 		initContainers,
-		buildCTDBSetNodeCtr(planner, ctdbEnv, ctdbInitVols.all()),
-		buildCTDBMustHaveNodeCtr(planner, ctdbEnv, ctdbInitVols.all()),
+		buildCTDBSetNodeCtr(planner, ctdbEnv, ctdbInitVols),
+		buildCTDBMustHaveNodeCtr(planner, ctdbEnv, ctdbInitVols),
 	)
 
 	ctdbdVols := podCfgVols.clone().
@@ -369,7 +369,7 @@ func buildClusteredADPodSpec(
 		add(ctdbSharedVol)
 	containers = append(
 		containers,
-		buildCTDBDaemonCtr(planner, ctdbEnv, ctdbdVols.all()))
+		buildCTDBDaemonCtr(planner, ctdbEnv, ctdbdVols))
 
 	ctdbManageNodesVols := podCfgVols.clone().
 		add(ctdbConfigVol).
@@ -377,7 +377,7 @@ func buildClusteredADPodSpec(
 		add(ctdbSharedVol)
 	containers = append(
 		containers,
-		buildCTDBManageNodesCtr(planner, ctdbEnv, ctdbManageNodesVols.all()))
+		buildCTDBManageNodesCtr(planner, ctdbEnv, ctdbManageNodesVols))
 
 	// winbindd
 	wbVols := podCfgVols.clone().
@@ -390,12 +390,12 @@ func buildClusteredADPodSpec(
 		add(ctdbSharedVol)
 	containers = append(
 		containers,
-		buildWinbinddCtr(planner, podEnv, wbVols.all()))
+		buildWinbinddCtr(planner, podEnv, wbVols))
 
 	// smbd
 	containers = append(
 		containers,
-		buildSmbdCtrs(planner, podEnv, volumes.all())...)
+		buildSmbdCtrs(planner, podEnv, volumes)...)
 
 	// dns-register containers
 	if planner.DNSRegister() != pln.DNSRegisterNever {
@@ -407,8 +407,8 @@ func buildClusteredADPodSpec(
 		dnsRegVols := wbVols.clone().add(watchVol)
 		containers = append(
 			containers,
-			buildSvcWatchCtr(planner, svcWatchEnv(planner), svcWatchVols.all()),
-			buildDNSRegCtr(planner, podEnv, dnsRegVols.all()),
+			buildSvcWatchCtr(planner, svcWatchEnv(planner), svcWatchVols),
+			buildDNSRegCtr(planner, podEnv, dnsRegVols),
 		)
 	}
 
@@ -422,7 +422,7 @@ func buildClusteredADPodSpec(
 func buildSmbdCtrs(
 	planner *pln.Planner,
 	env []corev1.EnvVar,
-	vols []volMount) []corev1.Container {
+	vols *volKeeper) []corev1.Container {
 	// ---
 	ctrs := []corev1.Container{}
 	ctrs = append(ctrs, buildSmbdCtr(planner, env, vols))
@@ -435,9 +435,10 @@ func buildSmbdCtrs(
 func buildSmbdCtr(
 	planner *pln.Planner,
 	env []corev1.EnvVar,
-	vols []volMount) corev1.Container {
+	vols *volKeeper) corev1.Container {
 	// ---
 	portnum := planner.GlobalConfig.SmbdPort
+	mounts := getMounts(vols.all())
 	return corev1.Container{
 		Image:   planner.GlobalConfig.SmbdContainerImage,
 		Name:    planner.GlobalConfig.SmbdContainerName,
@@ -448,7 +449,7 @@ func buildSmbdCtr(
 			ContainerPort: int32(portnum),
 			Name:          "smb",
 		}},
-		VolumeMounts: getMounts(vols),
+		VolumeMounts: mounts,
 		ReadinessProbe: &corev1.Probe{
 			Handler: corev1.Handler{
 				TCPSocket: &corev1.TCPSocketAction{
@@ -469,23 +470,25 @@ func buildSmbdCtr(
 func buildSmbdMetricsCtr(
 	planner *pln.Planner,
 	env []corev1.EnvVar,
-	vols []volMount) corev1.Container {
+	vols *volKeeper) corev1.Container {
 	// ---
+	mounts := getMounts(vols.all())
 	return buildSmbMetricsContainer(
-		planner.GlobalConfig.SmbdMetricsContainerImage, env, getMounts(vols))
+		planner.GlobalConfig.SmbdMetricsContainerImage, env, mounts)
 }
 
 func buildWinbinddCtr(
 	planner *pln.Planner,
 	env []corev1.EnvVar,
-	vols []volMount) corev1.Container {
+	vols *volKeeper) corev1.Container {
 	// ---
+	mounts := getMounts(vols.all())
 	return corev1.Container{
 		Image:        planner.GlobalConfig.SmbdContainerImage,
 		Name:         planner.GlobalConfig.WinbindContainerName,
 		Args:         planner.Args().Run("winbindd"),
 		Env:          env,
-		VolumeMounts: getMounts(vols),
+		VolumeMounts: mounts,
 		LivenessProbe: &corev1.Probe{
 			Handler: corev1.Handler{
 				Exec: &corev1.ExecAction{
@@ -503,14 +506,15 @@ func buildWinbinddCtr(
 func buildCTDBDaemonCtr(
 	planner *pln.Planner,
 	env []corev1.EnvVar,
-	vols []volMount) corev1.Container {
+	vols *volKeeper) corev1.Container {
 	// ---
+	mounts := getMounts(vols.all())
 	return corev1.Container{
 		Image:        planner.GlobalConfig.SmbdContainerImage,
 		Name:         "ctdb",
 		Args:         planner.Args().CTDBDaemon(),
 		Env:          env,
-		VolumeMounts: getMounts(vols),
+		VolumeMounts: mounts,
 		ReadinessProbe: &corev1.Probe{
 			Handler: corev1.Handler{
 				Exec: &corev1.ExecAction{
@@ -524,125 +528,134 @@ func buildCTDBDaemonCtr(
 func buildCTDBManageNodesCtr(
 	planner *pln.Planner,
 	env []corev1.EnvVar,
-	vols []volMount) corev1.Container {
+	vols *volKeeper) corev1.Container {
 	// ---
+	mounts := getMounts(vols.all())
 	return corev1.Container{
 		Image:        planner.GlobalConfig.SmbdContainerImage,
 		Name:         "ctdb-manage-nodes",
 		Args:         planner.Args().CTDBManageNodes(),
 		Env:          env,
-		VolumeMounts: getMounts(vols),
+		VolumeMounts: mounts,
 	}
 }
 
 func buildDNSRegCtr(
 	planner *pln.Planner,
 	env []corev1.EnvVar,
-	vols []volMount) corev1.Container {
+	vols *volKeeper) corev1.Container {
 	// ---
+	mounts := getMounts(vols.all())
 	return corev1.Container{
 		Image:        planner.GlobalConfig.SmbdContainerImage,
 		Name:         "dns-register",
 		Args:         planner.Args().DNSRegister(),
 		Env:          env,
-		VolumeMounts: getMounts(vols),
+		VolumeMounts: mounts,
 	}
 }
 
 func buildSvcWatchCtr(
 	planner *pln.Planner,
 	env []corev1.EnvVar,
-	vols []volMount) corev1.Container {
+	vols *volKeeper) corev1.Container {
 	// ---
+	mounts := getMounts(vols.all())
 	return corev1.Container{
 		Image:        planner.GlobalConfig.SvcWatchContainerImage,
 		Name:         "svc-watch",
 		Env:          env,
-		VolumeMounts: getMounts(vols),
+		VolumeMounts: mounts,
 	}
 }
 
 func buildInitCtr(
 	planner *pln.Planner,
 	env []corev1.EnvVar,
-	vols []volMount) corev1.Container {
+	vols *volKeeper) corev1.Container {
 	// ---
+	mounts := getMounts(vols.all())
 	return corev1.Container{
 		Image:        planner.GlobalConfig.SmbdContainerImage,
 		Name:         "init",
 		Args:         planner.Args().Initializer("init"),
 		Env:          env,
-		VolumeMounts: getMounts(vols),
+		VolumeMounts: mounts,
 	}
 }
 
 func buildEnsureShareCtr(
 	planner *pln.Planner,
 	env []corev1.EnvVar,
-	vols []volMount) corev1.Container {
+	vols *volKeeper) corev1.Container {
 	// ---
+	mounts := getMounts(vols.all())
 	return corev1.Container{
 		Image:        planner.GlobalConfig.SmbdContainerImage,
 		Name:         "ensure-share-paths",
 		Args:         planner.Args().EnsureSharePaths(),
 		Env:          env,
-		VolumeMounts: getMounts(vols),
+		VolumeMounts: mounts,
 	}
 }
 
 func buildMustJoinCtr(
 	planner *pln.Planner,
 	env []corev1.EnvVar,
-	vols []volMount) corev1.Container {
+	vols *volKeeper) corev1.Container {
 	// ---
+	mounts := getMounts(vols.all())
 	return corev1.Container{
 		Image:        planner.GlobalConfig.SmbdContainerImage,
 		Name:         "must-join",
 		Args:         planner.Args().Initializer("must-join"),
 		Env:          env,
-		VolumeMounts: getMounts(vols),
+		VolumeMounts: mounts,
 	}
 }
 
 func buildCTDBMigrateCtr(
 	planner *pln.Planner,
 	env []corev1.EnvVar,
-	vols []volMount) corev1.Container {
+	vols *volKeeper) corev1.Container {
 	// ---
+	mounts := getMounts(vols.all())
 	return corev1.Container{
 		Image:        planner.GlobalConfig.SmbdContainerImage,
 		Name:         "ctdb-migrate",
 		Args:         planner.Args().CTDBMigrate(),
 		Env:          env,
-		VolumeMounts: getMounts(vols),
+		VolumeMounts: mounts,
 	}
 }
 
 func buildCTDBSetNodeCtr(
 	planner *pln.Planner,
 	env []corev1.EnvVar,
-	vols []volMount) corev1.Container {
+	vols *volKeeper) corev1.Container {
 	// ---
+	mounts := getMounts(vols.all())
 	return corev1.Container{
 		Image:        planner.GlobalConfig.SmbdContainerImage,
 		Name:         "ctdb-set-node",
 		Args:         planner.Args().CTDBSetNode(),
 		Env:          env,
-		VolumeMounts: getMounts(vols),
+		VolumeMounts: mounts,
 	}
 }
 
 func buildCTDBMustHaveNodeCtr(
 	planner *pln.Planner,
 	env []corev1.EnvVar,
-	vols []volMount) corev1.Container {
+	vols *volKeeper) corev1.Container {
 	// ---
+	mounts := getMounts(vols.all())
 	return corev1.Container{
 		Image:        planner.GlobalConfig.SmbdContainerImage,
 		Name:         "ctdb-must-have-node",
 		Args:         planner.Args().CTDBMustHaveNode(),
 		Env:          env,
-		VolumeMounts: getMounts(vols),
+		VolumeMounts: mounts,
 	}
 }
 

--- a/internal/resources/pods.go
+++ b/internal/resources/pods.go
@@ -783,7 +783,3 @@ func getJoinSources(planner *pln.Planner) joinSources {
 func joinEnvPaths(p []string) string {
 	return strings.Join(p, ":")
 }
-
-func dupVolMounts(vols []volMount) []volMount {
-	return append(make([]volMount, 0, len(vols)), vols...)
-}

--- a/internal/resources/volumes_test.go
+++ b/internal/resources/volumes_test.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func genVolMount(name, path string, tag volMountTag) volMount {
+	var vmnt volMount
+	vmnt.volume = corev1.Volume{
+		Name: name,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{
+				Medium: corev1.StorageMediumMemory,
+			},
+		},
+	}
+	// mount
+	vmnt.mount = corev1.VolumeMount{
+		MountPath: path,
+		Name:      name,
+	}
+	vmnt.tag = tag
+	return vmnt
+}
+
+func TestVolKeeper(t *testing.T) {
+	vm1 := genVolMount("foo", "/mnt/foo", tagData)
+	vm2 := genVolMount("bar", "/var/bar", tagMeta)
+
+	vk1 := newVolKeeper()
+	assert.Len(t, vk1.all(), 0)
+
+	vk1.add(vm1)
+	vk1.add(vm2)
+	t.Run("lengthAfterAdd", func(t *testing.T) {
+		assert.Len(t, vk1.all(), 2)
+	})
+
+	vk2 := newVolKeeper()
+	assert.Len(t, vk2.all(), 0)
+
+	vk2.extend([]volMount{vm1, vm2})
+	t.Run("lengthAfterExtend", func(t *testing.T) {
+		assert.Len(t, vk2.all(), 2)
+	})
+
+	t.Run("clone", func(t *testing.T) {
+		vk3 := vk1.clone()
+		vall := vk3.all()
+		if assert.Len(t, vall, 2) {
+			assert.Equal(t, "foo", vall[0].volume.Name)
+			assert.Equal(t, "bar", vall[1].volume.Name)
+		}
+	})
+
+	t.Run("validateMismatch", func(t *testing.T) {
+		vk3 := vk1.clone()
+		assert.NoError(t, vk3.validate())
+		vm3 := genVolMount("baz", "/", tagData)
+		vm3.volume.Name = "bib"
+		vk3.add(vm3)
+		assert.Error(t, vk3.validate())
+	})
+	t.Run("validateDuplicate", func(t *testing.T) {
+		vk3 := vk1.clone()
+		assert.NoError(t, vk3.validate())
+		vm3 := genVolMount("foo", "/", tagData)
+		vk3.add(vm3)
+		assert.Error(t, vk3.validate())
+	})
+	t.Run("mustValidatePanics", func(t *testing.T) {
+		vk3 := vk1.clone()
+		vm3 := genVolMount("foo", "/", tagData)
+		vk3.add(vm3)
+		assert.Panics(t, func() {
+			vk3.mustValidate()
+		})
+	})
+
+	t.Run("exclude", func(t *testing.T) {
+		assert.Len(t, vk1.exclude(tagData).all(), 1)
+		assert.Len(t, vk1.exclude(tagMeta).all(), 1)
+		assert.Len(t, vk1.exclude(tagCTDBMeta).all(), 2)
+	})
+}


### PR DESCRIPTION
The current implementation of pod construction relies on managing many
slices of volMount objects. Not only is this a bit verbose but it also
relies on a trick that the static checkers don't like. In order to
make things a bit less "loose" and more regular the very simple
volKeeper type is added as a wrapper around a slice of volMounts.

The major pod assembly functions are then converted to use volKeepers.

This work is a precursor to additional patches that will add new containers to the pods
that will watch for configuration changes.