### PR TITLE
tests: append local-tools bin dir to PATH

### DIFF
--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,7 +1,12 @@
 #!/bin/sh
 
 set -e
-cd "$(dirname "${0}")/.."
+SELFDIR="$(dirname "${0}")"
+ROOTDIR="$(realpath "${SELFDIR}/../")"
+LOCAL_BINDIR="${ROOTDIR}/.bin"
+
+cd "${ROOTDIR}"
+export PATH=${PATH}:${LOCAL_BINDIR}
 
 gtest() {
     if [ "$SMBOP_TEST_CLUSTERED" ]; then


### PR DESCRIPTION
Some developers uses 'kustomize' from local '.bin' directory, and
therefore it should be appended to search PATH variable as part of
tests-execution wrapper script.

Signed-off-by: Shachar Sharon <ssharon@redhat.com>