### PR TITLE
golangci-lint: enable extra checks for 'govet'

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -43,6 +43,12 @@ linters-settings:
   funlen:
     lines: 188
     statements: 60
+  govet:
+    check-shadowing: true
+    enable-all: true
+    disable:
+      - fieldalignment
+      - shadow
   lll:
     line-length: 98
   revive:

--- a/internal/resources/smbshare.go
+++ b/internal/resources/smbshare.go
@@ -324,7 +324,7 @@ func (m *SmbShareManager) Finalize(
 			m.logger.Info("Updated config map during Finalize")
 			return Requeue
 		}
-	} else if err != nil && !errors.IsNotFound(err) {
+	} else if !errors.IsNotFound(err) {
 		return Result{err: err}
 	}
 


### PR DESCRIPTION
Make govet linter extra pedantic by enabling almost all checks. This in
turn revealed a minor dead-if in smbshare.

Signed-off-by: Shachar Sharon <ssharon@redhat.com>