### PR TITLE
tests: a script to dump various logs/state info 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -131,6 +131,9 @@ jobs:
         run: make set-image
       - name: run tests
         run: ./tests/test.sh
+      - name: dump logging on failure
+        if: ${{ failure() }}
+        run: ./tests/post-test-info.sh
   # push the container to quay.io - only for pushes, not PRs
   push:
     needs: [build, check]

--- a/tests/centosci/sink-clustered-deployment.sh
+++ b/tests/centosci/sink-clustered-deployment.sh
@@ -34,7 +34,7 @@ IMG="${CI_IMG_OP}" make test
 
 # Run integration tests
 SMBOP_TEST_CLUSTERED=1 SMBOP_TEST_EXPECT_MANAGER_IMG="${CI_IMG_OP}" \
-	./tests/test.sh
+	./tests/test.sh || (./tests/post-test-info.sh; exit 1)
 
 teardown_op
 

--- a/tests/centosci/sink-clustered-deployment.sh
+++ b/tests/centosci/sink-clustered-deployment.sh
@@ -13,7 +13,7 @@ setup_minikube
 
 deploy_rook
 
-image_pull ${CI_IMG_REGISTRY} "docker.io" "golang:1.17"
+image_pull "${CI_IMG_REGISTRY}" "docker.io" "golang:1.17"
 
 # Build and push operator image to local CI registry
 IMG="${CI_IMG_OP}" make image-build

--- a/tests/centosci/sink-common.sh
+++ b/tests/centosci/sink-common.sh
@@ -71,7 +71,7 @@ kubectl_retry() {
 
 minikube_load() {
 	for n in ${1}; do
-		${CONTAINER_CMD} image save ${2} | ssh \
+		${CONTAINER_CMD} image save "${2}" | ssh \
 			-o UserKnownHostsFile=/dev/null \
 			-o StrictHostKeyChecking=no \
 			-i "$(minikube ssh-key -n "$n")" \
@@ -84,6 +84,7 @@ setup_minikube() {
 	image_pull "${CI_IMG_REGISTRY}" "docker.io" "kindest/kindnetd:v20210326-1e038dc5"
 
 	# Start a kuberentes cluster using minikube
+	# shellcheck disable=SC2086
 	minikube start --force --driver="${VM_DRIVER}" --nodes="${NODE_COUNT}" \
 		--memory="${MEMORY}" --cpus="${CPUS}" ${DISK_CONFIG} \
 		--delete-on-failure --install-addons=false -b kubeadm \

--- a/tests/post-test-info.sh
+++ b/tests/post-test-info.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+#
+# A very simplistic script to help dump logs / diagnose test failures.
+#
+
+
+dump_operator_logs() {
+    ns="samba-operator-system"
+    echo "----> operator logs:"
+    kubectl -n "$ns" logs \
+        deploy/samba-operator-controller-manager \
+        --all-containers=true \
+        --prefix=true
+}
+
+dump_smb_pod_logs() {
+    ns="samba-operator-system"
+    echo "----> samba pod logs/info ($ns):"
+    podnames="$(kubectl -n "$ns" get pods \
+         -l app.kubernetes.io/name=samba \
+        -o go-template='{{range .items}}{{.metadata.name}}{{printf "\n"}}{{end}}')"
+    for pod in ${podnames}; do
+        echo "------> ${pod}"
+        kubectl -n "$ns" describe pod "${pod}"
+        kubectl -n "$ns" logs \
+            "pod/${pod}" \
+            --all-containers=true \
+            --prefix=true
+    done
+}
+
+
+echo "----- dumping logs --------------"
+dump_operator_logs
+dump_smb_pod_logs
+echo "---------------------------------"


### PR DESCRIPTION
When a test fails, especially if that test is a CI job running on remote systems, it is difficult to debug/diagnose issues. These changes add a script that can be run after the tests fail in order to grab some information about the state of the cluster, including operator logs.
It may not be sufficient to debug all issues/failures but it could be a helpful first step.