### PR TITLE
tests: patch dns-operator when running over OpenShift

### DIFF
--- a/tests/files/openshift-dns-snippet.template
+++ b/tests/files/openshift-dns-snippet.template
@@ -1,0 +1,18 @@
+{
+	"spec": {
+		"nodePlacement": {},
+		"servers": [
+			{
+				"forwardPlugin": {
+					"upstreams": [
+						"AD_SERVER_IP:53"
+					]
+				},
+				"name": "samba-ad",
+				"zones": [
+					"domain1.sink.test"
+				]
+	 		}
+		]
+	}
+}


### PR DESCRIPTION
When running over OpenShift need to patch the CRD of dns-operator in
order order to configure extra DNS entry for testing. Using 'jq' utility
to simplify JSON parsing.

See "DNS Operator in OpenShift Container Platform" in OpenShift's
documentations for examples.

Signed-off-by: Shachar Sharon <ssharon@redhat.com>