### PR TITLE
Add additional printer columns for SmbShare CR

### DIFF
--- a/api/v1alpha1/smbshare_types.go
+++ b/api/v1alpha1/smbshare_types.go
@@ -99,6 +99,7 @@ type SmbShareScalingSpec struct {
 	// for (high-)availability purposes.
 	// +optional
 	// +kubebuilder:validation:Enum:=standard;clustered
+	// +kubebuilder:default:=standard
 	AvailabilityMode string `json:"availabilityMode,omitempty"`
 	// MinClusterSize specifies the minimum number of smb server instances
 	// to establish when availabilityMode is "clustered".

--- a/api/v1alpha1/smbshare_types.go
+++ b/api/v1alpha1/smbshare_types.go
@@ -114,8 +114,15 @@ type SmbShareStatus struct {
 	ServerGroup string `json:"serverGroup,omitempty"`
 }
 
+// revive:disable:line-length-limit kubebuilder markers
+
+// nolint:lll
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:JSONPath=`.spec.shareName`,description="Name of the Samba share",name="Share-name",type=string
+// +kubebuilder:printcolumn:JSONPath=`.spec.storage.pvc.path`,description="Path for the share within PVC",name="Share-path",type=string
+// +kubebuilder:printcolumn:JSONPath=`.spec.scaling.availabilityMode`,description="Samba availability mode",name="Availability",type=string
+// +kubebuilder:printcolumn:JSONPath=`.metadata.creationTimestamp`,name="Age",type=date
 
 // SmbShare is the Schema for the smbshares API
 type SmbShare struct {
@@ -125,6 +132,8 @@ type SmbShare struct {
 	Spec   SmbShareSpec   `json:"spec,omitempty"`
 	Status SmbShareStatus `json:"status,omitempty"`
 }
+
+// revive:enable:line-length-limit
 
 // +kubebuilder:object:root=true
 

--- a/config/crd/bases/samba-operator.samba.org_smbshares.yaml
+++ b/config/crd/bases/samba-operator.samba.org_smbshares.yaml
@@ -14,7 +14,23 @@ spec:
     singular: smbshare
   scope: Namespaced
   versions:
-    - name: v1alpha1
+    - additionalPrinterColumns:
+        - description: Name of the Samba share
+          jsonPath: .spec.shareName
+          name: Share-name
+          type: string
+        - description: Path for the share within PVC
+          jsonPath: .spec.storage.pvc.path
+          name: Share-path
+          type: string
+        - description: Samba availability mode
+          jsonPath: .spec.scaling.availabilityMode
+          name: Availability
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha1
       schema:
         openAPIV3Schema:
           description: SmbShare is the Schema for the smbshares API
@@ -46,6 +62,7 @@ spec:
                   description: Scaling specifies parameters relating to how share resources can and should be scaled.
                   properties:
                     availabilityMode:
+                      default: standard
                       description: AvailabilityMode specifies how the operator is to scale share resources for (high-)availability purposes.
                       enum:
                         - standard


### PR DESCRIPTION
Apart from **AGE** following details are added to `kubectl get` output:
- .spec.sharename (**SHARE-NAME**)
- .spec.storage.pvc.path (**SHARE-PATH**)
- .spec.scaling.availabilitymode (**AVAILABILITY**)

Before:
```
# kubectl get smbshares
NAME      AGE
cshare1   2m1s
```

After:
```
# kubectl get smbshares
NAME      SHARE-NAME   SHARE-PATH   AVAILABILITY   AGE
cshare1   CTDB Me                   clustered      5m1s
```
 Above SmbShare CR was created using [smbshare_ctdb1.yaml](https://github.com/samba-in-kubernetes/samba-operator/blob/master/tests/files/smbshare_ctdb1.yaml)

Ref: https://book.kubebuilder.io/reference/markers/crd.html