### PR TITLE
resources: export pod's meta-info via env variables

### DIFF
--- a/internal/resources/metrics.go
+++ b/internal/resources/metrics.go
@@ -30,6 +30,7 @@ func annotationsForSmbMetricsPod() map[string]string {
 // buildSmbMetricsContainer returns the appropriate Container definition for
 // smbmetrics exporter.
 func buildSmbMetricsContainer(image string,
+	env []corev1.EnvVar,
 	volmnts []corev1.VolumeMount) corev1.Container {
 	portnum := defaultMetricsPort
 	return corev1.Container{
@@ -41,6 +42,7 @@ func buildSmbMetricsContainer(image string,
 			Name:          "smbmetrics",
 		}},
 		VolumeMounts: volmnts,
+		Env:          env,
 		ReadinessProbe: &corev1.Probe{
 			Handler: corev1.Handler{
 				TCPSocket: &corev1.TCPSocketAction{

--- a/internal/resources/pods.go
+++ b/internal/resources/pods.go
@@ -428,7 +428,7 @@ func buildSmbdCtrs(
 	ctrs := []corev1.Container{}
 	ctrs = append(ctrs, buildSmbdCtr(planner, env, vols))
 	if withMetricsExporter(planner.GlobalConfig) {
-		ctrs = append(ctrs, buildSmbdMetricsCtr(planner, vols))
+		ctrs = append(ctrs, buildSmbdMetricsCtr(planner, metaPodEnv(), vols))
 	}
 	return ctrs
 }
@@ -469,10 +469,11 @@ func buildSmbdCtr(
 
 func buildSmbdMetricsCtr(
 	planner *pln.Planner,
+	env []corev1.EnvVar,
 	vols []volMount) corev1.Container {
 	// ---
 	return buildSmbMetricsContainer(
-		planner.GlobalConfig.SmbdMetricsContainerImage, getMounts(vols))
+		planner.GlobalConfig.SmbdMetricsContainerImage, env, getMounts(vols))
 }
 
 func buildWinbinddCtr(
@@ -682,7 +683,29 @@ func defaultPodEnv(planner *pln.Planner) []corev1.EnvVar {
 			Value: lvl,
 		})
 	}
+	env = append(env, metaPodEnv()...)
 	return env
+}
+
+func metaPodEnv() []corev1.EnvVar {
+	return []corev1.EnvVar{
+		{
+			Name: "SAMBA_POD_NAME",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "metadata.name",
+				},
+			},
+		},
+		{
+			Name: "SAMBA_POD_NAMESPACE",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "metadata.namespace",
+				},
+			},
+		},
+	}
 }
 
 func defaultPodSpec(planner *pln.Planner) corev1.PodSpec {


### PR DESCRIPTION
Allow each smbd pod to discover it's own id (name and namespace) via
default environment variables. With those variables at hand, each
container within the pod may discover its current run-time properties.

Required in order to enable smbmetrics sidcar container to extern
current image information via Prometheus.

Signed-off-by: Shachar Sharon <ssharon@redhat.com>