### PR TITLE
tests/centosci: Do not cache docker images to nodes

### DIFF
--- a/tests/centosci/sink-common.sh
+++ b/tests/centosci/sink-common.sh
@@ -88,7 +88,8 @@ setup_minikube() {
 	minikube start --force --driver="${VM_DRIVER}" --nodes="${NODE_COUNT}" \
 		--memory="${MEMORY}" --cpus="${CPUS}" ${DISK_CONFIG} \
 		--delete-on-failure --install-addons=false -b kubeadm \
-		--kubernetes-version="${KUBE_VERSION}" ${EXTRA_CONFIG}
+		--kubernetes-version="${KUBE_VERSION}" --cache-images=false \
+		${EXTRA_CONFIG}
 
 	nodes=$(kubectl get nodes \
 			-o jsonpath='{range.items[*].metadata}{.name} {end}')


### PR DESCRIPTION
Caching of images consume more space within root file system(_/var/lib/minikube/images/_) which results in HEALTH_WARN state for Ceph cluster when available space(configured using `dataDirHostPath` as _/data/rook/_) gets below the default threshold value of 30%. Therefore for the the time being we refrain from caching docker images.