### PR TITLE
resources: Do not update Spec.Storage.Pvc.Path

### DIFF
--- a/internal/planner/configuration.go
+++ b/internal/planner/configuration.go
@@ -101,9 +101,6 @@ func (pl *Planner) Update() (changed bool, err error) {
 		}
 		pl.ConfigState.Shares[shareKey] = share
 		changed = true
-	} else if share.Options["path"] != pl.Paths().Share() {
-		// Update path if changed
-		share.Options["path"] = pl.Paths().Share()
 	}
 	cfgKey := pl.instanceID()
 	cfg, found := pl.ConfigState.Configs[cfgKey]


### PR DESCRIPTION
At the moment we only support setting the PVC path at creation time. We
do not support updating the path retrospectively. Remove the code which
updates the path since this could lead to a bug.

Signed-off-by: Sachin Prabhu <sprabhu@redhat.com>