### PR TITLE
tests: require pod-ready before testing metrics

### DIFF
--- a/tests/integration/smb_share_test.go
+++ b/tests/integration/smb_share_test.go
@@ -284,6 +284,8 @@ func (s *SmbShareWithExternalNetSuite) TestServiceIsLoadBalancer() {
 }
 
 func (s *SmbShareSuite) TestMetricsOnPod() {
+	s.Require().NoError(waitForPodReady(s))
+
 	pod, cont, err := s.getMetricsContainer()
 	s.Require().NoError(err)
 	if cont == nil {


### PR DESCRIPTION
Even when metrics is disabled, we need a ready pod in order to check
the samba-metrics container. Expects samba pod to be ready before poking
into the pod's state. Without this check the test would fail, but with
an enigmatic error message.

Signed-off-by: Shachar Sharon <ssharon@redhat.com>