### PR TITLE
centosci: Update golang pre-pulled image version to 1.18

### DIFF
--- a/tests/centosci/sink-clustered-deployment.sh
+++ b/tests/centosci/sink-clustered-deployment.sh
@@ -13,7 +13,7 @@ setup_minikube
 
 deploy_rook
 
-image_pull "${CI_IMG_REGISTRY}" "docker.io" "golang:1.17"
+image_pull "${CI_IMG_REGISTRY}" "docker.io" "golang:1.18"
 
 # Build and push operator image to local CI registry
 IMG="${CI_IMG_OP}" make image-build


### PR DESCRIPTION
Following the [change](https://github.com/samba-in-kubernetes/samba-operator/pull/201) to use updated(v1.18) golang base container image for building operator CI registry now mirrors golang:1.18 which can be consumed within corresponding script running integration tests on CentOS CI.