### PR TITLE
resources: pass smbdVols to buildEnsureShareCtr

### DIFF
--- a/internal/resources/pods.go
+++ b/internal/resources/pods.go
@@ -113,7 +113,7 @@ func buildADPodSpec(
 	podSpec.Volumes = getVolumes(volumes)
 	podSpec.InitContainers = []corev1.Container{
 		buildInitCtr(planner, podEnv, smbAllVols),
-		buildEnsureShareCtr(planner, podEnv, smbAllVols),
+		buildEnsureShareCtr(planner, podEnv, smbdVols),
 		buildMustJoinCtr(planner, joinEnv, joinVols),
 	}
 	podSpec.Containers = containers


### PR DESCRIPTION
Commit b140141 ("resources: create ensure-share-paths init container")
introduced a new init container, which changes the mode of share's
directory. Unfortunately, in buildADPodSpec we pass the wrong volumes
slice (a slice which does _not_ have the share volume). This bug is
evident only when running with smbmetrics enabled, on OpenShift.

Signed-off-by: Shachar Sharon <ssharon@redhat.com>