### PR TITLE
config: default to latest samba operator image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ endif
 .PHONY: developer-dir
 
 set-image: kustomize $(MGR_KUST_DIR)/kustomization.yaml
-	cd $(MGR_KUST_DIR) && $(KUSTOMIZE) edit set image controller=$(IMG)
+	cd $(MGR_KUST_DIR) && $(KUSTOMIZE) edit set image quay.io/samba.org/samba-operator=$(IMG)
 .PHONY: set-image
 
 # Generate manifests e.g. CRD, RBAC etc.

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -38,7 +38,7 @@ spec:
           envFrom:
             - configMapRef:
                 name: controller-cfg
-          image: controller:latest
+          image: quay.io/samba.org/samba-operator:latest
           imagePullPolicy: Always
           name: manager
           resources:


### PR DESCRIPTION
Since using the Operator SDK to create the initial kustomization files
we've defaulted to 'controller:latest' in the base yamls. However, this
means one *must* use kustomize to set the image to something. Typically,
we've been doing this using the Makefile.
However, now that we've well established that the canonical image for
the operator is at 'quay.io/samba.org/samba-operator' there's really no
need to require the image to be overridden. Update the manager base
YAML to default to the canonical operator image repo - and update the
makefile to match.


Note: if you do have an existing   kustomization.yaml  referring to 'controller' you need to update that manually