### PR TITLE
makefile: minor fixes needed to match planned tagging format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ BUNDLE_DEFAULT_CHANNEL:=--default-channel=$(DEFAULT_CHANNEL)
 endif
 BUNDLE_METADATA_OPTS?=$(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 
-COMMIT_ID=$(shell git describe --abbrev=40 --always --dirty=+ 2>/dev/null)
-GIT_VERSION=$(shell git describe --match='v[0-9]*.[0-9].[0-9]' 2>/dev/null || echo "(unset)")
+COMMIT_ID=$(shell git describe --abbrev=40 --always --exclude='*' --dirty=+ 2>/dev/null)
+GIT_VERSION=$(shell git describe --match='v[0-9]*.[0-9]' --match='v[0-9]*.[0-9].[0-9]' 2>/dev/null || echo "(unset)")
 
 CONFIG_KUST_DIR:=config/default
 CRD_KUST_DIR:=config/crd


### PR DESCRIPTION
We want the makefile to help us embed the version and hash of the git
checkout used for the build. Fix getting the hash when a tag is applied
and when the tag is in the form vX.Y (rather than vX.Y.Z).

