### PR TITLE
Integration test organizational cleanups

### DIFF
--- a/tests/integration/cleanup_test.go
+++ b/tests/integration/cleanup_test.go
@@ -212,11 +212,11 @@ func (s *ShareCreateDeleteSuite) TestCreateAndDelete() {
 		len(rs2.statefulSets.Items), len(existing.statefulSets.Items))
 }
 
-func allShareCreateDeleteSuites() map[string]suite.TestingSuite {
-	m := map[string]suite.TestingSuite{}
+func init() {
 	ns := testNamespace
+	createDeleteTests := testRoot.Child("createDelete")
 
-	m["simple"] = &ShareCreateDeleteSuite{
+	createDeleteTests.AddSuite("simple", &ShareCreateDeleteSuite{
 		fileSources: []kube.FileSource{
 			{
 				Path:      path.Join(testFilesDir, "userssecret1.yaml"),
@@ -235,8 +235,10 @@ func allShareCreateDeleteSuites() map[string]suite.TestingSuite {
 		smbShareResource: types.NamespacedName{ns, "tshare1"},
 		maxPods:          1,
 		minPods:          1,
-	}
-	m["domainMember"] = &ShareCreateDeleteSuite{
+	},
+	)
+
+	createDeleteTests.AddSuite("domainMember", &ShareCreateDeleteSuite{
 		fileSources: []kube.FileSource{
 			{
 				Path:      path.Join(testFilesDir, "joinsecret1.yaml"),
@@ -255,10 +257,11 @@ func allShareCreateDeleteSuites() map[string]suite.TestingSuite {
 		smbShareResource: types.NamespacedName{testNamespace, "tshare2"},
 		maxPods:          1,
 		minPods:          1,
-	}
+	},
+	)
 
 	// should we use a namespace other than default for this test?
-	m["altNamespace"] = &ShareCreateDeleteSuite{
+	createDeleteTests.AddSuite("altNamespace", &ShareCreateDeleteSuite{
 		fileSources: []kube.FileSource{
 			{
 				Path:      path.Join(testFilesDir, "userssecret1.yaml"),
@@ -277,10 +280,11 @@ func allShareCreateDeleteSuites() map[string]suite.TestingSuite {
 		smbShareResource: types.NamespacedName{"default", "tshare3"},
 		maxPods:          1,
 		minPods:          1,
-	}
+	},
+	)
 
 	if testClusteredShares {
-		m["clustered"] = &ShareCreateDeleteSuite{
+		createDeleteTests.AddSuite("clustered", &ShareCreateDeleteSuite{
 			fileSources: []kube.FileSource{
 				{
 					Path:      path.Join(testFilesDir, "userssecret1.yaml"),
@@ -300,8 +304,10 @@ func allShareCreateDeleteSuites() map[string]suite.TestingSuite {
 			smbShareResource: types.NamespacedName{ns, "cshare1-cleanme"},
 			maxPods:          3,
 			minPods:          2,
-		}
-		m["clusteredDomainMember"] = &ShareCreateDeleteSuite{
+		},
+		)
+
+		createDeleteTests.AddSuite("clusteredDomainMember", &ShareCreateDeleteSuite{
 			fileSources: []kube.FileSource{
 				{
 					Path:      path.Join(testFilesDir, "joinsecret1.yaml"),
@@ -321,8 +327,7 @@ func allShareCreateDeleteSuites() map[string]suite.TestingSuite {
 			smbShareResource: types.NamespacedName{ns, "cshare2-cleanme"},
 			maxPods:          3,
 			minPods:          2,
-		}
+		},
+		)
 	}
-
-	return m
 }

--- a/tests/integration/cleanup_test.go
+++ b/tests/integration/cleanup_test.go
@@ -214,7 +214,7 @@ func (s *ShareCreateDeleteSuite) TestCreateAndDelete() {
 
 func init() {
 	ns := testNamespace
-	createDeleteTests := testRoot.Child("createDelete")
+	createDeleteTests := testRoot.ChildPriority("createDelete", 2)
 
 	createDeleteTests.AddSuite("simple", &ShareCreateDeleteSuite{
 		fileSources: []kube.FileSource{

--- a/tests/integration/common_test.go
+++ b/tests/integration/common_test.go
@@ -5,6 +5,7 @@ package integration
 
 import (
 	"os"
+	"strconv"
 )
 
 var (
@@ -18,6 +19,8 @@ var (
 	testExpectedImage = "quay.io/samba.org/samba-operator:latest"
 
 	testClusteredShares = false
+
+	testShuffleOrder = false
 )
 
 func init() {
@@ -53,5 +56,10 @@ func init() {
 	testClustering := os.Getenv("SMBOP_TEST_CLUSTERED")
 	if testClustering != "" {
 		testClusteredShares = true
+	}
+
+	shuffleEnv := os.Getenv("SMBOP_TEST_SHUFFLE")
+	if b, err := strconv.ParseBool(shuffleEnv); b && err == nil {
+		testShuffleOrder = true
 	}
 }

--- a/tests/integration/deploy_test.go
+++ b/tests/integration/deploy_test.go
@@ -98,10 +98,8 @@ func (s DeploySuite) TestImageAndTag() {
 	require.Equal(testExpectedImage, ctrImage)
 }
 
-func allDeploySuites() map[string]suite.TestingSuite {
-	m := map[string]suite.TestingSuite{}
-	m["default"] = &DeploySuite{
+func init() {
+	testRoot.AddSuite("deploy", &DeploySuite{
 		sharedConfigDir: path.Join(operatorConfigDir, "default"),
-	}
-	return m
+	})
 }

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -12,16 +12,6 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-func runSuiteTests(sm map[string]suite.TestingSuite) func(t *testing.T) {
-	return func(t *testing.T) {
-		for name, ts := range sm {
-			t.Run(name, func(t *testing.T) {
-				suite.Run(t, ts)
-			})
-		}
-	}
-}
-
 type namedSuite struct {
 	name      string
 	testSuite suite.TestingSuite

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -19,6 +19,49 @@ func runSuiteTests(sm map[string]suite.TestingSuite) func(t *testing.T) {
 	}
 }
 
+type namedSuite struct {
+	name      string
+	testSuite suite.TestingSuite
+}
+
+type TestingGroup interface {
+	Name() string
+	Run(*testing.T)
+}
+
+type TestGroup struct {
+	name     string
+	children []TestingGroup
+	suites   []namedSuite
+}
+
+func (tg *TestGroup) Run(t *testing.T) {
+	for _, s := range tg.suites {
+		t.Run(s.name, func(t *testing.T) {
+			suite.Run(t, s.testSuite)
+		})
+	}
+	for _, child := range tg.children {
+		t.Run(child.Name(), child.Run)
+	}
+}
+
+func (tg *TestGroup) Name() string {
+	return tg.name
+}
+
+func (tg *TestGroup) Child(name string) *TestGroup {
+	child := &TestGroup{name: name}
+	tg.children = append(tg.children, child)
+	return child
+}
+
+func (tg *TestGroup) AddSuite(n string, s suite.TestingSuite) {
+	tg.suites = append(tg.suites, namedSuite{name: n, testSuite: s})
+}
+
+var testRoot *TestGroup = &TestGroup{}
+
 func TestIntegration(t *testing.T) {
 	t.Run("deploy", runSuiteTests(allDeploySuites()))
 	t.Run("smbShares", runSuiteTests(allSmbShareSuites()))

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -63,8 +63,5 @@ func (tg *TestGroup) AddSuite(n string, s suite.TestingSuite) {
 var testRoot *TestGroup = &TestGroup{}
 
 func TestIntegration(t *testing.T) {
-	t.Run("deploy", runSuiteTests(allDeploySuites()))
-	t.Run("smbShares", runSuiteTests(allSmbShareSuites()))
-	t.Run("createDelete", runSuiteTests(allShareCreateDeleteSuites()))
-	t.Run("reconciliation", runSuiteTests(allReconcileSuites()))
+	testRoot.Run(t)
 }

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -17,19 +17,24 @@ type namedSuite struct {
 	testSuite suite.TestingSuite
 }
 
+// TestingGroup provides an interface to run groups of tests.
 type TestingGroup interface {
 	Name() string
 	Run(*testing.T)
 }
 
+// Prioritized is an interface for checking a type's priority.
 type Prioritized interface {
 	Priority() int
 }
 
+// Shuffler is an interface for shuffling an object's contents.
 type Shuffler interface {
 	Shuffle()
 }
 
+// TestGroup contains other tests to run.
+// Tests can be testify test suites or other child TestingGroups.
 type TestGroup struct {
 	name     string
 	prio     int
@@ -37,6 +42,7 @@ type TestGroup struct {
 	suites   []namedSuite
 }
 
+// Run all contained tests.
 func (tg *TestGroup) Run(t *testing.T) {
 	for _, s := range tg.suites {
 		t.Run(s.name, func(t *testing.T) {
@@ -48,18 +54,23 @@ func (tg *TestGroup) Run(t *testing.T) {
 	}
 }
 
+// Name of the test group.
 func (tg *TestGroup) Name() string {
 	return tg.name
 }
 
+// Priority of the test group. Lower value is higher priority.
 func (tg *TestGroup) Priority() int {
 	return tg.prio
 }
 
+// Child returns an new child test group with the provided name.
 func (tg *TestGroup) Child(name string) *TestGroup {
 	return tg.ChildPriority(name, 1)
 }
 
+// ChildPriority returns a new child test group with the provided
+// name and priority value.
 func (tg *TestGroup) ChildPriority(name string, prio int) *TestGroup {
 	child := &TestGroup{name: name, prio: prio}
 	tg.children = append(tg.children, child)
@@ -77,6 +88,7 @@ func (tg *TestGroup) ChildPriority(name string, prio int) *TestGroup {
 	return child
 }
 
+// AddSuite adds a test suite to the group.
 func (tg *TestGroup) AddSuite(n string, s suite.TestingSuite) {
 	tg.suites = append(tg.suites, namedSuite{name: n, testSuite: s})
 }
@@ -106,6 +118,8 @@ func (tg *TestGroup) Shuffle() {
 
 var testRoot *TestGroup = &TestGroup{}
 
+// TestIntegration is the base test to start running our hierarchical
+// integration test "super-suite".
 func TestIntegration(t *testing.T) {
 	if testShuffleOrder {
 		t.Log("shuffling test order")

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -117,5 +117,9 @@ func (tg *TestGroup) Shuffle() {
 var testRoot *TestGroup = &TestGroup{}
 
 func TestIntegration(t *testing.T) {
+	if testShuffleOrder {
+		t.Log("shuffling test order")
+		testRoot.Shuffle()
+	}
 	testRoot.Run(t)
 }

--- a/tests/integration/mount_path_test.go
+++ b/tests/integration/mount_path_test.go
@@ -129,7 +129,7 @@ func (s *MountPathSuite) TestMountPath() {
 }
 
 func init() {
-	mountPathTests := testRoot.Child("mountPath")
+	mountPathTests := testRoot.ChildPriority("mountPath", 3)
 	mountPathTests.AddSuite("default", &MountPathSuite{
 		auths: []smbclient.Auth{
 			{

--- a/tests/integration/reconcile_test.go
+++ b/tests/integration/reconcile_test.go
@@ -156,7 +156,7 @@ func init() {
 		return
 	}
 
-	reconTests := testRoot.Child("reconciliation")
+	reconTests := testRoot.ChildPriority("reconciliation", 4)
 	reconTests.AddSuite("limitAvailModeChangeStandard", &limitAvailModeChangeSuite{
 		fileSources: []kube.FileSource{
 			{

--- a/tests/integration/reconcile_test.go
+++ b/tests/integration/reconcile_test.go
@@ -151,67 +151,73 @@ func (s *scaleoutClusterSuite) TestScaleoutClusterSuite() {
 	require.Equal(int32(newClusterSize), *l.Items[0].Spec.Replicas, "Clustersize not as expected")
 }
 
-func allReconcileSuites() map[string]suite.TestingSuite {
-	m := map[string]suite.TestingSuite{}
-	if testClusteredShares {
-		m["limitAvailModeChangeStandard"] = &limitAvailModeChangeSuite{
-			fileSources: []kube.FileSource{
-				{
-					Path:      path.Join(testFilesDir, "userssecret1.yaml"),
-					Namespace: testNamespace,
-				},
-				{
-					Path:      path.Join(testFilesDir, "smbsecurityconfig1.yaml"),
-					Namespace: testNamespace,
-				},
-				{
-					Path:       path.Join(testFilesDir, "smbshare1.yaml"),
-					Namespace:  testNamespace,
-					NameSuffix: "-bk",
-				},
-			},
-			smbShareResource: types.NamespacedName{testNamespace, "tshare1-bk"},
-			expectBackend:    "standard",
-			nextMode:         "clustered",
-		}
-		m["limitAvailModeChangeClustered"] = &limitAvailModeChangeSuite{
-			fileSources: []kube.FileSource{
-				{
-					Path:      path.Join(testFilesDir, "userssecret1.yaml"),
-					Namespace: testNamespace,
-				},
-				{
-					Path:      path.Join(testFilesDir, "smbsecurityconfig1.yaml"),
-					Namespace: testNamespace,
-				},
-				{
-					Path:       path.Join(testFilesDir, "smbshare_ctdb1.yaml"),
-					Namespace:  testNamespace,
-					NameSuffix: "-bk",
-				},
-			},
-			smbShareResource: types.NamespacedName{testNamespace, "cshare1-bk"},
-			expectBackend:    "clustered",
-			nextMode:         "standard",
-		}
-		m["scaleoutCluster"] = &scaleoutClusterSuite{
-			fileSources: []kube.FileSource{
-				{
-					Path:      path.Join(testFilesDir, "userssecret1.yaml"),
-					Namespace: testNamespace,
-				},
-				{
-					Path:      path.Join(testFilesDir, "smbsecurityconfig1.yaml"),
-					Namespace: testNamespace,
-				},
-				{
-					Path:       path.Join(testFilesDir, "smbshare_ctdb1.yaml"),
-					Namespace:  testNamespace,
-					NameSuffix: "-soc",
-				},
-			},
-			smbShareResource: types.NamespacedName{testNamespace, "cshare1-soc"},
-		}
+func init() {
+	if !testClusteredShares {
+		return
 	}
-	return m
+
+	reconTests := testRoot.Child("reconciliation")
+	reconTests.AddSuite("limitAvailModeChangeStandard", &limitAvailModeChangeSuite{
+		fileSources: []kube.FileSource{
+			{
+				Path:      path.Join(testFilesDir, "userssecret1.yaml"),
+				Namespace: testNamespace,
+			},
+			{
+				Path:      path.Join(testFilesDir, "smbsecurityconfig1.yaml"),
+				Namespace: testNamespace,
+			},
+			{
+				Path:       path.Join(testFilesDir, "smbshare1.yaml"),
+				Namespace:  testNamespace,
+				NameSuffix: "-bk",
+			},
+		},
+		smbShareResource: types.NamespacedName{testNamespace, "tshare1-bk"},
+		expectBackend:    "standard",
+		nextMode:         "clustered",
+	},
+	)
+
+	reconTests.AddSuite("limitAvailModeChangeClustered", &limitAvailModeChangeSuite{
+		fileSources: []kube.FileSource{
+			{
+				Path:      path.Join(testFilesDir, "userssecret1.yaml"),
+				Namespace: testNamespace,
+			},
+			{
+				Path:      path.Join(testFilesDir, "smbsecurityconfig1.yaml"),
+				Namespace: testNamespace,
+			},
+			{
+				Path:       path.Join(testFilesDir, "smbshare_ctdb1.yaml"),
+				Namespace:  testNamespace,
+				NameSuffix: "-bk",
+			},
+		},
+		smbShareResource: types.NamespacedName{testNamespace, "cshare1-bk"},
+		expectBackend:    "clustered",
+		nextMode:         "standard",
+	},
+	)
+
+	reconTests.AddSuite("scaleoutCluster", &scaleoutClusterSuite{
+		fileSources: []kube.FileSource{
+			{
+				Path:      path.Join(testFilesDir, "userssecret1.yaml"),
+				Namespace: testNamespace,
+			},
+			{
+				Path:      path.Join(testFilesDir, "smbsecurityconfig1.yaml"),
+				Namespace: testNamespace,
+			},
+			{
+				Path:       path.Join(testFilesDir, "smbshare_ctdb1.yaml"),
+				Namespace:  testNamespace,
+				NameSuffix: "-soc",
+			},
+		},
+		smbShareResource: types.NamespacedName{testNamespace, "cshare1-soc"},
+	},
+	)
 }

--- a/tests/integration/smb_share_test.go
+++ b/tests/integration/smb_share_test.go
@@ -339,7 +339,7 @@ func (s *SmbShareSuite) getMetricsContainer() (
 func init() {
 	utilruntime.Must(sambaoperatorv1alpha1.AddToScheme(kube.TypedClientScheme))
 
-	smbShareTests := testRoot.Child("smbShares")
+	smbShareTests := testRoot.ChildPriority("smbShares", 1)
 	smbShareTests.AddSuite("users1", &SmbShareSuite{
 		fileSources: []kube.FileSource{
 			{
@@ -445,7 +445,7 @@ func init() {
 	)
 
 	if testClusteredShares {
-		clusteredTests := testRoot.Child("smbSharesClustered")
+		clusteredTests := testRoot.ChildPriority("smbSharesClustered", 1)
 		clusteredTests.AddSuite("default", &SmbShareSuite{
 			fileSources: []kube.FileSource{
 				{


### PR DESCRIPTION
I started working on making the tests more robust and immediately became annoyed with our approach to organization as well a the semi-non-deterministic execution of the test due to our use of a map.

This may be a bit overkill but I hope it makes things more maintainable and less prone to becoming a jumble if parts are copy-n-pasted in the future.

The new TestGroup type allows a much more consistent and deterministic way of grouping test suites and other (child) test groups. Beyond this PR the hope is that one only needs to think about the test group very rarely and can mostly copy the structure of the `init`functions in the other files that have test suites to execute.

Because determinism could possibly lead to implicit dependencies between tests I also amused myself by adding a Shuffle method that can be invoked through an environment variable. This causes the tests to be run in a randomized order. It is not enabled by default. I have not committed to the idea, but I am considering enabling it for the scheduled runs of the CI (but not PRs). Either way, its there in case we (I) want it.

This is part one of many(?) organizational changes of the integration tests as I hack my way through the weeds that have grown in the test code.