### PR TITLE
integration test: use unique names for SmbShare resources

### DIFF
--- a/tests/integration/cleanup_test.go
+++ b/tests/integration/cleanup_test.go
@@ -58,6 +58,7 @@ func (s *ShareCreateDeleteSuite) defaultContext() context.Context {
 
 func (s *ShareCreateDeleteSuite) SetupSuite() {
 	s.testID = generateTestID()
+	s.T().Logf("test ID: %s", s.testID)
 	s.tc = kube.NewTestClient("")
 }
 

--- a/tests/integration/cleanup_test.go
+++ b/tests/integration/cleanup_test.go
@@ -115,6 +115,8 @@ func (s *ShareCreateDeleteSuite) waitForNoSmbServices() error {
 			if err != nil {
 				return false, err
 			}
+			s.T().Logf("found samba server pod in namespace: %s",
+				s.destNamespace)
 			return false, nil
 		},
 	})
@@ -193,6 +195,7 @@ func (s *ShareCreateDeleteSuite) TestCreateAndDelete() {
 	defer cancel()
 
 	// remove smbshare
+	s.T().Log("removing smb share resource")
 	smbShare := &sambaoperatorv1alpha1.SmbShare{}
 	smbShare.Namespace = s.testShareName.Namespace
 	smbShare.Name = s.testShareName.Name
@@ -200,6 +203,7 @@ func (s *ShareCreateDeleteSuite) TestCreateAndDelete() {
 	require.NoError(err)
 
 	// wait for smbshare to go away
+	s.T().Log("waiting for server resources to be removed")
 	require.NoError(poll.TryUntil(ctx2, &poll.Prober{
 		Cond: func() (bool, error) {
 			smbShare := &sambaoperatorv1alpha1.SmbShare{}
@@ -220,6 +224,7 @@ func (s *ShareCreateDeleteSuite) TestCreateAndDelete() {
 	err = s.waitForNoSmbServices()
 	require.NoError(err)
 
+	s.T().Log("removing prerequisite resources")
 	deleteFromFiles(ctx, require, s.tc, s.fileSources)
 	time.Sleep(waitForClearTime)
 

--- a/tests/integration/cleanup_test.go
+++ b/tests/integration/cleanup_test.go
@@ -37,7 +37,7 @@ type ShareCreateDeleteSuite struct {
 	suite.Suite
 
 	fileSources     []kube.FileSource
-	smbshareSources []kube.FileSource
+	smbShareSources []kube.FileSource
 	destNamespace   string
 	maxPods         int
 	minPods         int
@@ -171,7 +171,7 @@ func (s *ShareCreateDeleteSuite) TestCreateAndDelete() {
 		ctx,
 		s.Require(),
 		s.tc,
-		s.smbshareSources,
+		s.smbShareSources,
 		s.testID,
 	)
 	s.Require().Len(names, 1, "expected one smb share resource")
@@ -256,7 +256,7 @@ func init() {
 				Namespace: ns,
 			},
 		},
-		smbshareSources: []kube.FileSource{
+		smbShareSources: []kube.FileSource{
 			{
 				Path:      path.Join(testFilesDir, "smbshare1.yaml"),
 				Namespace: ns,
@@ -279,7 +279,7 @@ func init() {
 				Namespace: testNamespace,
 			},
 		},
-		smbshareSources: []kube.FileSource{
+		smbShareSources: []kube.FileSource{
 			{
 				Path:      path.Join(testFilesDir, "smbshare2.yaml"),
 				Namespace: testNamespace,
@@ -303,7 +303,7 @@ func init() {
 				Namespace: "default",
 			},
 		},
-		smbshareSources: []kube.FileSource{
+		smbShareSources: []kube.FileSource{
 			{
 				Path:      path.Join(testFilesDir, "smbshare3.yaml"),
 				Namespace: "default",
@@ -327,7 +327,7 @@ func init() {
 					Namespace: ns,
 				},
 			},
-			smbshareSources: []kube.FileSource{
+			smbShareSources: []kube.FileSource{
 				{
 					Path:      path.Join(testFilesDir, "smbshare_ctdb1.yaml"),
 					Namespace: ns,
@@ -350,7 +350,7 @@ func init() {
 					Namespace: ns,
 				},
 			},
-			smbshareSources: []kube.FileSource{
+			smbShareSources: []kube.FileSource{
 				{
 					Path:      path.Join(testFilesDir, "smbshare_ctdb2.yaml"),
 					Namespace: ns,

--- a/tests/integration/cleanup_test.go
+++ b/tests/integration/cleanup_test.go
@@ -36,7 +36,7 @@ type resourceSnapshot struct {
 type ShareCreateDeleteSuite struct {
 	suite.Suite
 
-	fileSources     []kube.FileSource
+	commonSources   []kube.FileSource
 	smbShareSources []kube.FileSource
 	destNamespace   string
 	maxPods         int
@@ -75,7 +75,7 @@ func (s *ShareCreateDeleteSuite) SetupTest() {
 }
 
 func (s *ShareCreateDeleteSuite) TearDownSuite() {
-	deleteFromFiles(s.defaultContext(), s.Require(), s.tc, s.fileSources)
+	deleteFromFiles(s.defaultContext(), s.Require(), s.tc, s.commonSources)
 }
 
 func (s *ShareCreateDeleteSuite) getTestClient() *kube.TestClient {
@@ -165,7 +165,7 @@ func (s *ShareCreateDeleteSuite) TestCreateAndDelete() {
 	existing := s.getCurrentResources()
 
 	s.T().Log("creating prerequisite resources")
-	createFromFiles(ctx, require, s.tc, s.fileSources)
+	createFromFiles(ctx, require, s.tc, s.commonSources)
 	s.T().Log("creating smb share resource")
 	names := createFromFilesWithSuffix(
 		ctx,
@@ -226,7 +226,7 @@ func (s *ShareCreateDeleteSuite) TestCreateAndDelete() {
 	require.NoError(err)
 
 	s.T().Log("removing prerequisite resources")
-	deleteFromFiles(ctx, require, s.tc, s.fileSources)
+	deleteFromFiles(ctx, require, s.tc, s.commonSources)
 	time.Sleep(waitForClearTime)
 
 	rs2 := s.getCurrentResources()
@@ -246,7 +246,7 @@ func init() {
 	createDeleteTests := testRoot.ChildPriority("createDelete", 2)
 
 	createDeleteTests.AddSuite("simple", &ShareCreateDeleteSuite{
-		fileSources: []kube.FileSource{
+		commonSources: []kube.FileSource{
 			{
 				Path:      path.Join(testFilesDir, "userssecret1.yaml"),
 				Namespace: ns,
@@ -269,7 +269,7 @@ func init() {
 	)
 
 	createDeleteTests.AddSuite("domainMember", &ShareCreateDeleteSuite{
-		fileSources: []kube.FileSource{
+		commonSources: []kube.FileSource{
 			{
 				Path:      path.Join(testFilesDir, "joinsecret1.yaml"),
 				Namespace: testNamespace,
@@ -293,7 +293,7 @@ func init() {
 
 	// should we use a namespace other than default for this test?
 	createDeleteTests.AddSuite("altNamespace", &ShareCreateDeleteSuite{
-		fileSources: []kube.FileSource{
+		commonSources: []kube.FileSource{
 			{
 				Path:      path.Join(testFilesDir, "userssecret1.yaml"),
 				Namespace: "default",
@@ -317,7 +317,7 @@ func init() {
 
 	if testClusteredShares {
 		createDeleteTests.AddSuite("clustered", &ShareCreateDeleteSuite{
-			fileSources: []kube.FileSource{
+			commonSources: []kube.FileSource{
 				{
 					Path:      path.Join(testFilesDir, "userssecret1.yaml"),
 					Namespace: ns,
@@ -340,7 +340,7 @@ func init() {
 		)
 
 		createDeleteTests.AddSuite("clusteredDomainMember", &ShareCreateDeleteSuite{
-			fileSources: []kube.FileSource{
+			commonSources: []kube.FileSource{
 				{
 					Path:      path.Join(testFilesDir, "joinsecret1.yaml"),
 					Namespace: ns,

--- a/tests/integration/mount_path_test.go
+++ b/tests/integration/mount_path_test.go
@@ -21,8 +21,8 @@ type MountPathSuite struct {
 
 	auths                []smbclient.Auth
 	commonSources        []kube.FileSource
-	smbshareSetupSources []kube.FileSource
-	smbshareSources      []kube.FileSource
+	smbShareSetupSources []kube.FileSource
+	smbShareSources      []kube.FileSource
 
 	// tc is a TestClient instance
 	tc *kube.TestClient
@@ -73,7 +73,7 @@ func (s *MountPathSuite) SetupSuite() {
 		ctx,
 		require,
 		s.tc,
-		s.smbshareSetupSources,
+		s.smbShareSetupSources,
 		s.testID,
 	)
 	require.Len(names, 1, "expected one smb share resource")
@@ -111,7 +111,7 @@ func (s *MountPathSuite) SetupSuite() {
 	require.NoError(err)
 
 	// Delete the smbshare created
-	deleteFromFilesWithSuffix(ctx, require, s.tc, s.smbshareSetupSources, s.testID)
+	deleteFromFilesWithSuffix(ctx, require, s.tc, s.smbShareSetupSources, s.testID)
 
 	// Create smbshare with Spec.Storage.PVC.Path specified
 	createFromFiles(ctx, require, s.tc, s.commonSources)
@@ -119,7 +119,7 @@ func (s *MountPathSuite) SetupSuite() {
 		ctx,
 		require,
 		s.tc,
-		s.smbshareSources,
+		s.smbShareSources,
 		s.testID,
 	)
 	require.Len(names, 1, "expected one smb share resource")
@@ -132,8 +132,8 @@ func (s *MountPathSuite) SetupSuite() {
 func (s *MountPathSuite) TearDownSuite() {
 	ctx := s.defaultContext()
 	require := s.Require()
-	deleteFromFilesWithSuffix(ctx, require, s.tc, s.smbshareSources, s.testID)
-	deleteFromFilesWithSuffix(ctx, require, s.tc, s.smbshareSetupSources, s.testID)
+	deleteFromFilesWithSuffix(ctx, require, s.tc, s.smbShareSources, s.testID)
+	deleteFromFilesWithSuffix(ctx, require, s.tc, s.smbShareSetupSources, s.testID)
 	deleteFromFiles(ctx, require, s.tc, s.commonSources)
 }
 
@@ -187,13 +187,13 @@ func init() {
 				Namespace: testNamespace,
 			},
 		},
-		smbshareSetupSources: []kube.FileSource{
+		smbShareSetupSources: []kube.FileSource{
 			{
 				Path:      path.Join(testFilesDir, "smbsharepvc1.yaml"),
 				Namespace: testNamespace,
 			},
 		},
-		smbshareSources: []kube.FileSource{
+		smbShareSources: []kube.FileSource{
 			{
 				Path:      path.Join(testFilesDir, "smbsharepvc2.yaml"),
 				Namespace: testNamespace,
@@ -213,7 +213,7 @@ func init() {
 				Namespace: testNamespace,
 			},
 		},
-		smbshareSources: []kube.FileSource{
+		smbShareSources: []kube.FileSource{
 			{
 				Path:      path.Join(testFilesDir, "smbshare1.yaml"),
 				Namespace: testNamespace,

--- a/tests/integration/mount_path_test.go
+++ b/tests/integration/mount_path_test.go
@@ -60,6 +60,7 @@ func (s *MountPathSuite) waitForPods(labelPattern string) {
 
 func (s *MountPathSuite) SetupSuite() {
 	s.testID = generateTestID()
+	s.T().Logf("test ID: %s", s.testID)
 	s.tc = kube.NewTestClient("")
 	ctx := s.defaultContext()
 	require := s.Require()

--- a/tests/integration/path_permissions.go
+++ b/tests/integration/path_permissions.go
@@ -56,6 +56,7 @@ func (s *MountPathPermissionsSuite) waitForPods(labelPattern string) {
 
 func (s *MountPathPermissionsSuite) SetupSuite() {
 	s.testID = generateTestID()
+	s.T().Logf("test ID: %s", s.testID)
 	s.tc = kube.NewTestClient("")
 	require := s.Require()
 

--- a/tests/integration/path_permissions.go
+++ b/tests/integration/path_permissions.go
@@ -18,7 +18,7 @@ type MountPathPermissionsSuite struct {
 	suite.Suite
 
 	commonSources   []kube.FileSource
-	smbshareSources []kube.FileSource
+	smbShareSources []kube.FileSource
 
 	// tc is a TestClient instance
 	tc *kube.TestClient
@@ -67,7 +67,7 @@ func (s *MountPathPermissionsSuite) SetupSuite() {
 		ctx,
 		s.Require(),
 		s.tc,
-		s.smbshareSources,
+		s.smbShareSources,
 		s.testID,
 	)
 	s.Require().Len(names, 1, "expected one smb share resource")
@@ -79,7 +79,7 @@ func (s *MountPathPermissionsSuite) SetupSuite() {
 
 func (s *MountPathPermissionsSuite) TearDownSuite() {
 	ctx := s.defaultContext()
-	deleteFromFilesWithSuffix(ctx, s.Require(), s.tc, s.smbshareSources, s.testID)
+	deleteFromFilesWithSuffix(ctx, s.Require(), s.tc, s.smbShareSources, s.testID)
 	deleteFromFiles(ctx, s.Require(), s.tc, s.commonSources)
 }
 

--- a/tests/integration/reconcile_test.go
+++ b/tests/integration/reconcile_test.go
@@ -44,6 +44,7 @@ func (s *limitAvailModeChangeSuite) defaultContext() context.Context {
 
 func (s *limitAvailModeChangeSuite) SetupSuite() {
 	s.testID = generateTestID()
+	s.T().Logf("test ID: %s", s.testID)
 	// ensure the smbclient test pod exists
 	require := s.Require()
 	s.tc = kube.NewTestClient("")
@@ -136,6 +137,7 @@ func (s *scaleoutClusterSuite) defaultContext() context.Context {
 
 func (s *scaleoutClusterSuite) SetupSuite() {
 	s.testID = generateTestID()
+	s.T().Logf("test ID: %s", s.testID)
 	// ensure the smbclient test pod exists
 	ctx := s.defaultContext()
 	require := s.Require()

--- a/tests/integration/reconcile_test.go
+++ b/tests/integration/reconcile_test.go
@@ -23,7 +23,7 @@ var (
 type limitAvailModeChangeSuite struct {
 	suite.Suite
 
-	fileSources     []kube.FileSource
+	commonSources   []kube.FileSource
 	smbShareSources []kube.FileSource
 	nextMode        string
 	expectBackend   string
@@ -49,7 +49,7 @@ func (s *limitAvailModeChangeSuite) SetupSuite() {
 	require := s.Require()
 	s.tc = kube.NewTestClient("")
 	ctx := s.defaultContext()
-	createFromFiles(ctx, require, s.tc, s.fileSources)
+	createFromFiles(ctx, require, s.tc, s.commonSources)
 	names := createFromFilesWithSuffix(
 		ctx,
 		s.Require(),
@@ -65,7 +65,7 @@ func (s *limitAvailModeChangeSuite) SetupSuite() {
 
 func (s *limitAvailModeChangeSuite) TearDownSuite() {
 	ctx := s.defaultContext()
-	deleteFromFiles(ctx, s.Require(), s.tc, s.fileSources)
+	deleteFromFiles(ctx, s.Require(), s.tc, s.commonSources)
 	deleteFromFilesWithSuffix(
 		ctx,
 		s.Require(),
@@ -118,7 +118,7 @@ func (s *limitAvailModeChangeSuite) TestAvailModeUnchanged() {
 type scaleoutClusterSuite struct {
 	suite.Suite
 
-	fileSources     []kube.FileSource
+	commonSources   []kube.FileSource
 	smbShareSources []kube.FileSource
 
 	// cached values
@@ -143,7 +143,7 @@ func (s *scaleoutClusterSuite) SetupSuite() {
 	require := s.Require()
 	s.tc = kube.NewTestClient("")
 	createSMBClientIfMissing(ctx, require, s.tc)
-	createFromFiles(ctx, require, s.tc, s.fileSources)
+	createFromFiles(ctx, require, s.tc, s.commonSources)
 	names := createFromFilesWithSuffix(
 		ctx,
 		s.Require(),
@@ -159,7 +159,7 @@ func (s *scaleoutClusterSuite) SetupSuite() {
 
 func (s *scaleoutClusterSuite) TearDownSuite() {
 	ctx := s.defaultContext()
-	deleteFromFiles(ctx, s.Require(), s.tc, s.fileSources)
+	deleteFromFiles(ctx, s.Require(), s.tc, s.commonSources)
 	deleteFromFilesWithSuffix(
 		ctx,
 		s.Require(),
@@ -218,7 +218,7 @@ func init() {
 
 	reconTests := testRoot.ChildPriority("reconciliation", 4)
 	reconTests.AddSuite("limitAvailModeChangeStandard", &limitAvailModeChangeSuite{
-		fileSources: []kube.FileSource{
+		commonSources: []kube.FileSource{
 			{
 				Path:      path.Join(testFilesDir, "userssecret1.yaml"),
 				Namespace: testNamespace,
@@ -240,7 +240,7 @@ func init() {
 	)
 
 	reconTests.AddSuite("limitAvailModeChangeClustered", &limitAvailModeChangeSuite{
-		fileSources: []kube.FileSource{
+		commonSources: []kube.FileSource{
 			{
 				Path:      path.Join(testFilesDir, "userssecret1.yaml"),
 				Namespace: testNamespace,
@@ -262,7 +262,7 @@ func init() {
 	)
 
 	reconTests.AddSuite("scaleoutCluster", &scaleoutClusterSuite{
-		fileSources: []kube.FileSource{
+		commonSources: []kube.FileSource{
 			{
 				Path:      path.Join(testFilesDir, "userssecret1.yaml"),
 				Namespace: testNamespace,

--- a/tests/integration/reconcile_test.go
+++ b/tests/integration/reconcile_test.go
@@ -24,7 +24,7 @@ type limitAvailModeChangeSuite struct {
 	suite.Suite
 
 	fileSources     []kube.FileSource
-	smbshareSources []kube.FileSource
+	smbShareSources []kube.FileSource
 	nextMode        string
 	expectBackend   string
 
@@ -54,7 +54,7 @@ func (s *limitAvailModeChangeSuite) SetupSuite() {
 		ctx,
 		s.Require(),
 		s.tc,
-		s.smbshareSources,
+		s.smbShareSources,
 		s.testID,
 	)
 	s.Require().Len(names, 1, "expected one smb share resource")
@@ -70,7 +70,7 @@ func (s *limitAvailModeChangeSuite) TearDownSuite() {
 		ctx,
 		s.Require(),
 		s.tc,
-		s.smbshareSources,
+		s.smbShareSources,
 		s.testID)
 }
 
@@ -119,7 +119,7 @@ type scaleoutClusterSuite struct {
 	suite.Suite
 
 	fileSources     []kube.FileSource
-	smbshareSources []kube.FileSource
+	smbShareSources []kube.FileSource
 
 	// cached values
 	tc *kube.TestClient
@@ -148,7 +148,7 @@ func (s *scaleoutClusterSuite) SetupSuite() {
 		ctx,
 		s.Require(),
 		s.tc,
-		s.smbshareSources,
+		s.smbShareSources,
 		s.testID,
 	)
 	s.Require().Len(names, 1, "expected one smb share resource")
@@ -164,7 +164,7 @@ func (s *scaleoutClusterSuite) TearDownSuite() {
 		ctx,
 		s.Require(),
 		s.tc,
-		s.smbshareSources,
+		s.smbShareSources,
 		s.testID)
 }
 
@@ -228,7 +228,7 @@ func init() {
 				Namespace: testNamespace,
 			},
 		},
-		smbshareSources: []kube.FileSource{
+		smbShareSources: []kube.FileSource{
 			{
 				Path:      path.Join(testFilesDir, "smbshare1.yaml"),
 				Namespace: testNamespace,
@@ -250,7 +250,7 @@ func init() {
 				Namespace: testNamespace,
 			},
 		},
-		smbshareSources: []kube.FileSource{
+		smbShareSources: []kube.FileSource{
 			{
 				Path:      path.Join(testFilesDir, "smbshare_ctdb1.yaml"),
 				Namespace: testNamespace,
@@ -272,7 +272,7 @@ func init() {
 				Namespace: testNamespace,
 			},
 		},
-		smbshareSources: []kube.FileSource{
+		smbShareSources: []kube.FileSource{
 			{
 				Path:      path.Join(testFilesDir, "smbshare_ctdb1.yaml"),
 				Namespace: testNamespace,

--- a/tests/integration/reconcile_test.go
+++ b/tests/integration/reconcile_test.go
@@ -23,13 +23,19 @@ var (
 type limitAvailModeChangeSuite struct {
 	suite.Suite
 
-	fileSources      []kube.FileSource
-	smbShareResource types.NamespacedName
-	nextMode         string
-	expectBackend    string
+	fileSources     []kube.FileSource
+	smbshareSources []kube.FileSource
+	nextMode        string
+	expectBackend   string
 
 	// cached values
 	tc *kube.TestClient
+
+	// testID is a short unique test id, pseudo-randomly generated
+	testID string
+	// testShareName is the name of the SmbShare being tested by this
+	// test instance
+	testShareName types.NamespacedName
 }
 
 func (s *limitAvailModeChangeSuite) defaultContext() context.Context {
@@ -37,17 +43,34 @@ func (s *limitAvailModeChangeSuite) defaultContext() context.Context {
 }
 
 func (s *limitAvailModeChangeSuite) SetupSuite() {
+	s.testID = generateTestID()
 	// ensure the smbclient test pod exists
 	require := s.Require()
 	s.tc = kube.NewTestClient("")
 	ctx := s.defaultContext()
 	createFromFiles(ctx, require, s.tc, s.fileSources)
+	names := createFromFilesWithSuffix(
+		ctx,
+		s.Require(),
+		s.tc,
+		s.smbshareSources,
+		s.testID,
+	)
+	s.Require().Len(names, 1, "expected one smb share resource")
+	s.testShareName = names[0]
 	require.NoError(waitForPodExist(ctx, s), "smb server pod does not exist")
 	require.NoError(waitForPodReady(ctx, s), "smb server pod is not ready")
 }
 
 func (s *limitAvailModeChangeSuite) TearDownSuite() {
-	deleteFromFiles(s.defaultContext(), s.Require(), s.tc, s.fileSources)
+	ctx := s.defaultContext()
+	deleteFromFiles(ctx, s.Require(), s.tc, s.fileSources)
+	deleteFromFilesWithSuffix(
+		ctx,
+		s.Require(),
+		s.tc,
+		s.smbshareSources,
+		s.testID)
 }
 
 func (s *limitAvailModeChangeSuite) getTestClient() *kube.TestClient {
@@ -56,9 +79,9 @@ func (s *limitAvailModeChangeSuite) getTestClient() *kube.TestClient {
 
 func (s *limitAvailModeChangeSuite) getPodFetchOptions() kube.PodFetchOptions {
 	l := fmt.Sprintf(
-		"samba-operator.samba.org/service=%s", s.smbShareResource.Name)
+		"samba-operator.samba.org/service=%s", s.testShareName.Name)
 	return kube.PodFetchOptions{
-		Namespace:     s.smbShareResource.Namespace,
+		Namespace:     s.testShareName.Namespace,
 		LabelSelector: l,
 		MaxFound:      3,
 	}
@@ -69,7 +92,7 @@ func (s *limitAvailModeChangeSuite) TestAvailModeUnchanged() {
 	require := s.Require()
 	smbShare := &sambaoperatorv1alpha1.SmbShare{}
 	err := s.tc.TypedObjectClient().Get(
-		ctx, s.smbShareResource, smbShare)
+		ctx, s.testShareName, smbShare)
 	require.NoError(err)
 	require.NotNil(smbShare.Annotations)
 	require.Contains(smbShare.Annotations[backendAnnotation], s.expectBackend)
@@ -85,7 +108,7 @@ func (s *limitAvailModeChangeSuite) TestAvailModeUnchanged() {
 	require.NoError(waitForPodExist(ctx, s), "smb server pod does not exist")
 	require.NoError(waitForPodReady(ctx, s), "smb server pod is not ready")
 	err = s.tc.TypedObjectClient().Get(
-		ctx, s.smbShareResource, smbShare)
+		ctx, s.testShareName, smbShare)
 	require.NoError(err)
 	require.NotNil(smbShare.Annotations)
 	require.Contains(smbShare.Annotations[backendAnnotation], s.expectBackend)
@@ -94,11 +117,17 @@ func (s *limitAvailModeChangeSuite) TestAvailModeUnchanged() {
 type scaleoutClusterSuite struct {
 	suite.Suite
 
-	fileSources      []kube.FileSource
-	smbShareResource types.NamespacedName
+	fileSources     []kube.FileSource
+	smbshareSources []kube.FileSource
 
 	// cached values
 	tc *kube.TestClient
+
+	// testID is a short unique test id, pseudo-randomly generated
+	testID string
+	// testShareName is the name of the SmbShare being tested by this
+	// test instance
+	testShareName types.NamespacedName
 }
 
 func (s *scaleoutClusterSuite) defaultContext() context.Context {
@@ -106,18 +135,35 @@ func (s *scaleoutClusterSuite) defaultContext() context.Context {
 }
 
 func (s *scaleoutClusterSuite) SetupSuite() {
+	s.testID = generateTestID()
 	// ensure the smbclient test pod exists
 	ctx := s.defaultContext()
 	require := s.Require()
 	s.tc = kube.NewTestClient("")
 	createSMBClientIfMissing(ctx, require, s.tc)
 	createFromFiles(ctx, require, s.tc, s.fileSources)
+	names := createFromFilesWithSuffix(
+		ctx,
+		s.Require(),
+		s.tc,
+		s.smbshareSources,
+		s.testID,
+	)
+	s.Require().Len(names, 1, "expected one smb share resource")
+	s.testShareName = names[0]
 	require.NoError(waitForPodExist(ctx, s), "smb server pod does not exist")
 	require.NoError(waitForPodReady(ctx, s), "smb server pod is not ready")
 }
 
 func (s *scaleoutClusterSuite) TearDownSuite() {
-	deleteFromFiles(s.defaultContext(), s.Require(), s.tc, s.fileSources)
+	ctx := s.defaultContext()
+	deleteFromFiles(ctx, s.Require(), s.tc, s.fileSources)
+	deleteFromFilesWithSuffix(
+		ctx,
+		s.Require(),
+		s.tc,
+		s.smbshareSources,
+		s.testID)
 }
 
 func (s *scaleoutClusterSuite) getTestClient() *kube.TestClient {
@@ -126,9 +172,9 @@ func (s *scaleoutClusterSuite) getTestClient() *kube.TestClient {
 
 func (s *scaleoutClusterSuite) getPodFetchOptions() kube.PodFetchOptions {
 	l := fmt.Sprintf(
-		"samba-operator.samba.org/service=%s", s.smbShareResource.Name)
+		"samba-operator.samba.org/service=%s", s.testShareName.Name)
 	return kube.PodFetchOptions{
-		Namespace:     s.smbShareResource.Namespace,
+		Namespace:     s.testShareName.Namespace,
 		LabelSelector: l,
 		MaxFound:      3,
 	}
@@ -139,7 +185,7 @@ func (s *scaleoutClusterSuite) TestScaleoutClusterSuite() {
 	require := s.Require()
 	smbShare := &sambaoperatorv1alpha1.SmbShare{}
 	err := s.tc.TypedObjectClient().Get(
-		ctx, s.smbShareResource, smbShare)
+		ctx, s.testShareName, smbShare)
 	require.NoError(err)
 
 	// Increase Cluster Size by 1 and check result
@@ -151,11 +197,11 @@ func (s *scaleoutClusterSuite) TestScaleoutClusterSuite() {
 	require.NoError(waitForPodExist(ctx, s), "smb server pod does not exist")
 	require.NoError(waitForPodReady(ctx, s), "smb server pod is not ready")
 
-	l, err := s.tc.Clientset().AppsV1().StatefulSets(s.smbShareResource.Namespace).List(
+	l, err := s.tc.Clientset().AppsV1().StatefulSets(s.testShareName.Namespace).List(
 		ctx,
 		metav1.ListOptions{
 			LabelSelector: fmt.Sprintf("samba-operator.samba.org/service=%s",
-				s.smbShareResource.Name),
+				s.testShareName.Name),
 		})
 	require.NoError(err)
 	// Only one stateful set should be available for this smbshare.
@@ -179,15 +225,15 @@ func init() {
 				Path:      path.Join(testFilesDir, "smbsecurityconfig1.yaml"),
 				Namespace: testNamespace,
 			},
+		},
+		smbshareSources: []kube.FileSource{
 			{
-				Path:       path.Join(testFilesDir, "smbshare1.yaml"),
-				Namespace:  testNamespace,
-				NameSuffix: "-bk",
+				Path:      path.Join(testFilesDir, "smbshare1.yaml"),
+				Namespace: testNamespace,
 			},
 		},
-		smbShareResource: types.NamespacedName{testNamespace, "tshare1-bk"},
-		expectBackend:    "standard",
-		nextMode:         "clustered",
+		expectBackend: "standard",
+		nextMode:      "clustered",
 	},
 	)
 
@@ -201,15 +247,15 @@ func init() {
 				Path:      path.Join(testFilesDir, "smbsecurityconfig1.yaml"),
 				Namespace: testNamespace,
 			},
+		},
+		smbshareSources: []kube.FileSource{
 			{
-				Path:       path.Join(testFilesDir, "smbshare_ctdb1.yaml"),
-				Namespace:  testNamespace,
-				NameSuffix: "-bk",
+				Path:      path.Join(testFilesDir, "smbshare_ctdb1.yaml"),
+				Namespace: testNamespace,
 			},
 		},
-		smbShareResource: types.NamespacedName{testNamespace, "cshare1-bk"},
-		expectBackend:    "clustered",
-		nextMode:         "standard",
+		expectBackend: "clustered",
+		nextMode:      "standard",
 	},
 	)
 
@@ -223,13 +269,13 @@ func init() {
 				Path:      path.Join(testFilesDir, "smbsecurityconfig1.yaml"),
 				Namespace: testNamespace,
 			},
+		},
+		smbshareSources: []kube.FileSource{
 			{
-				Path:       path.Join(testFilesDir, "smbshare_ctdb1.yaml"),
-				Namespace:  testNamespace,
-				NameSuffix: "-soc",
+				Path:      path.Join(testFilesDir, "smbshare_ctdb1.yaml"),
+				Namespace: testNamespace,
 			},
 		},
-		smbShareResource: types.NamespacedName{testNamespace, "cshare1-soc"},
 	},
 	)
 }

--- a/tests/integration/smb_share_test.go
+++ b/tests/integration/smb_share_test.go
@@ -29,7 +29,7 @@ type SmbShareSuite struct {
 	suite.Suite
 
 	fileSources     []kube.FileSource
-	smbshareSources []kube.FileSource
+	smbShareSources []kube.FileSource
 	shareName       string
 	testAuths       []smbclient.Auth
 	destNamespace   string
@@ -70,7 +70,7 @@ func (s *SmbShareSuite) SetupSuite() {
 		s.maxPods = 1
 	}
 	s.Require().Len(
-		s.smbshareSources, 1, "currently only one share may be tested")
+		s.smbShareSources, 1, "currently only one share may be tested")
 	s.tc = kube.NewTestClient("")
 	// ensure the smbclient test pod exists
 	ctx := s.defaultContext()
@@ -80,7 +80,7 @@ func (s *SmbShareSuite) SetupSuite() {
 		ctx,
 		s.Require(),
 		s.tc,
-		s.smbshareSources,
+		s.smbShareSources,
 		s.testID,
 	)
 	s.Require().Len(names, 1, "expected one smb share resource")
@@ -101,7 +101,7 @@ func (s *SmbShareSuite) TearDownSuite() {
 		ctx,
 		s.Require(),
 		s.tc,
-		s.smbshareSources,
+		s.smbShareSources,
 		s.testID)
 	s.waitForCleanup()
 }
@@ -438,7 +438,7 @@ func init() {
 				Namespace: testNamespace,
 			},
 		},
-		smbshareSources: []kube.FileSource{
+		smbShareSources: []kube.FileSource{
 			{
 				Path:      path.Join(testFilesDir, "smbshare1.yaml"),
 				Namespace: testNamespace,
@@ -463,7 +463,7 @@ func init() {
 				Namespace: testNamespace,
 			},
 		},
-		smbshareSources: []kube.FileSource{
+		smbShareSources: []kube.FileSource{
 			{
 				Path:      path.Join(testFilesDir, "smbshare2.yaml"),
 				Namespace: testNamespace,
@@ -491,7 +491,7 @@ func init() {
 				Namespace: "default",
 			},
 		},
-		smbshareSources: []kube.FileSource{
+		smbShareSources: []kube.FileSource{
 			{
 				Path:      path.Join(testFilesDir, "smbshare3.yaml"),
 				Namespace: "default",
@@ -521,7 +521,7 @@ func init() {
 				Namespace: testNamespace,
 			},
 		},
-		smbshareSources: []kube.FileSource{
+		smbShareSources: []kube.FileSource{
 			{
 				Path:      path.Join(testFilesDir, "smbshare4.yaml"),
 				Namespace: testNamespace,
@@ -548,7 +548,7 @@ func init() {
 					Namespace: testNamespace,
 				},
 			},
-			smbshareSources: []kube.FileSource{
+			smbShareSources: []kube.FileSource{
 				{
 					Path:      path.Join(testFilesDir, "smbshare_ctdb1.yaml"),
 					Namespace: testNamespace,
@@ -574,7 +574,7 @@ func init() {
 					Namespace: testNamespace,
 				},
 			},
-			smbshareSources: []kube.FileSource{
+			smbShareSources: []kube.FileSource{
 				{
 					Path:      path.Join(testFilesDir, "smbshare_ctdb2.yaml"),
 					Namespace: testNamespace,
@@ -600,7 +600,7 @@ func init() {
 					Namespace: testNamespace,
 				},
 			},
-			smbshareSources: []kube.FileSource{
+			smbShareSources: []kube.FileSource{
 				{
 					Path:      path.Join(testFilesDir, "smbshare_ctdb2.yaml"),
 					Namespace: testNamespace,
@@ -631,7 +631,7 @@ func init() {
 					Namespace: testNamespace,
 				},
 			},
-			smbshareSources: []kube.FileSource{
+			smbShareSources: []kube.FileSource{
 				{
 					Path:      path.Join(testFilesDir, "smbshare_ctdb3.yaml"),
 					Namespace: testNamespace,

--- a/tests/integration/smb_share_test.go
+++ b/tests/integration/smb_share_test.go
@@ -28,7 +28,7 @@ import (
 type SmbShareSuite struct {
 	suite.Suite
 
-	fileSources     []kube.FileSource
+	commonSources   []kube.FileSource
 	smbShareSources []kube.FileSource
 	shareName       string
 	testAuths       []smbclient.Auth
@@ -75,7 +75,7 @@ func (s *SmbShareSuite) SetupSuite() {
 	// ensure the smbclient test pod exists
 	ctx := s.defaultContext()
 	createSMBClientIfMissing(ctx, s.Require(), s.tc)
-	createFromFiles(ctx, s.Require(), s.tc, s.fileSources)
+	createFromFiles(ctx, s.Require(), s.tc, s.commonSources)
 	names := createFromFilesWithSuffix(
 		ctx,
 		s.Require(),
@@ -96,7 +96,7 @@ func (s *SmbShareSuite) SetupTest() {
 
 func (s *SmbShareSuite) TearDownSuite() {
 	ctx := s.defaultContext()
-	deleteFromFiles(ctx, s.Require(), s.tc, s.fileSources)
+	deleteFromFiles(ctx, s.Require(), s.tc, s.commonSources)
 	deleteFromFilesWithSuffix(
 		ctx,
 		s.Require(),
@@ -428,7 +428,7 @@ func init() {
 
 	smbShareTests := testRoot.ChildPriority("smbShares", 1)
 	smbShareTests.AddSuite("users1", &SmbShareSuite{
-		fileSources: []kube.FileSource{
+		commonSources: []kube.FileSource{
 			{
 				Path:      path.Join(testFilesDir, "userssecret1.yaml"),
 				Namespace: testNamespace,
@@ -453,7 +453,7 @@ func init() {
 	)
 
 	smbShareTests.AddSuite("domainMember1", &SmbShareWithDNSSuite{SmbShareSuite{
-		fileSources: []kube.FileSource{
+		commonSources: []kube.FileSource{
 			{
 				Path:      path.Join(testFilesDir, "joinsecret1.yaml"),
 				Namespace: testNamespace,
@@ -481,7 +481,7 @@ func init() {
 	// in a different ns (for example, "default").
 	// IMPORTANT: the secrets MUST be in the same namespace as the pods.
 	smbShareTests.AddSuite("smbSharesInDefault", &SmbShareSuite{
-		fileSources: []kube.FileSource{
+		commonSources: []kube.FileSource{
 			{
 				Path:      path.Join(testFilesDir, "userssecret1.yaml"),
 				Namespace: "default",
@@ -507,7 +507,7 @@ func init() {
 	)
 
 	smbShareTests.AddSuite("smbSharesExternal", &SmbShareWithExternalNetSuite{SmbShareSuite{
-		fileSources: []kube.FileSource{
+		commonSources: []kube.FileSource{
 			{
 				Path:      path.Join(testFilesDir, "userssecret1.yaml"),
 				Namespace: testNamespace,
@@ -538,7 +538,7 @@ func init() {
 	if testClusteredShares {
 		clusteredTests := testRoot.ChildPriority("smbSharesClustered", 1)
 		clusteredTests.AddSuite("default", &SmbShareSuite{
-			fileSources: []kube.FileSource{
+			commonSources: []kube.FileSource{
 				{
 					Path:      path.Join(testFilesDir, "userssecret1.yaml"),
 					Namespace: testNamespace,
@@ -564,7 +564,7 @@ func init() {
 		)
 
 		clusteredTests.AddSuite("noDNS", &SmbShareSuite{
-			fileSources: []kube.FileSource{
+			commonSources: []kube.FileSource{
 				{
 					Path:      path.Join(testFilesDir, "joinsecret1.yaml"),
 					Namespace: testNamespace,
@@ -590,7 +590,7 @@ func init() {
 		)
 
 		clusteredTests.AddSuite("withDNS", &SmbShareWithDNSSuite{SmbShareSuite{
-			fileSources: []kube.FileSource{
+			commonSources: []kube.FileSource{
 				{
 					Path:      path.Join(testFilesDir, "joinsecret1.yaml"),
 					Namespace: testNamespace,
@@ -617,7 +617,7 @@ func init() {
 		)
 
 		clusteredTests.AddSuite("external", &SmbShareWithExternalNetSuite{SmbShareSuite{
-			fileSources: []kube.FileSource{
+			commonSources: []kube.FileSource{
 				{
 					Path:      path.Join(testFilesDir, "joinsecret1.yaml"),
 					Namespace: testNamespace,

--- a/tests/integration/smb_share_test.go
+++ b/tests/integration/smb_share_test.go
@@ -62,6 +62,7 @@ func (s *SmbShareSuite) defaultContext() context.Context {
 
 func (s *SmbShareSuite) SetupSuite() {
 	s.testID = generateTestID()
+	s.T().Logf("test ID: %s", s.testID)
 	if s.destNamespace == "" {
 		s.destNamespace = testNamespace
 	}

--- a/tests/integration/util_test.go
+++ b/tests/integration/util_test.go
@@ -29,6 +29,8 @@ var (
 	waitForReadyTime = 200 * time.Second
 	waitForClearTime = 200 * time.Millisecond
 	clientCreateTime = 120 * time.Second
+	// waitForCleanupTime is twice the wait for pods time
+	waitForCleanupTime = 240 * time.Second
 )
 
 type checker interface {


### PR DESCRIPTION
Depends on: #224 

Fixes: #222

To help reduce various possible conflicts between the tests as the re-use the same YAML files over and over for test sources, it's better to have unique names for the resources we create. It can also help tie them back to the tests that
created them. This can also help avoid name conflicts between test cases and across test runs.

Because we want to have unique names we also have to remove some of the more "static" configuration input parameters. This is also a good cleanup as we should not assume the operator will name the server resource after the share. In the future, this should be derived from the serverGroup status field. However, we don't want to do too much in these patches.

