### PR TITLE
Integration tests: improve smbclient login test

### DIFF
--- a/tests/integration/share_access_test.go
+++ b/tests/integration/share_access_test.go
@@ -5,11 +5,18 @@ package integration
 
 import (
 	"context"
+	"time"
 
 	"github.com/stretchr/testify/suite"
 
 	"github.com/samba-in-kubernetes/samba-operator/tests/utils/kube"
+	"github.com/samba-in-kubernetes/samba-operator/tests/utils/poll"
 	"github.com/samba-in-kubernetes/samba-operator/tests/utils/smbclient"
+)
+
+const (
+	loginTestTimeout  = 10 * time.Second
+	loginTestInterval = 500 * time.Millisecond
 )
 
 type ShareAccessSuite struct {
@@ -44,17 +51,33 @@ func (s *ShareAccessSuite) SetupSuite() {
 // TestLogin verifies that users can log into the share.
 func (s *ShareAccessSuite) TestLogin() {
 	ctx := s.defaultContext()
+	require := s.Require()
 	tc := kube.NewTestClient("")
-	smbclient := smbclient.MustPodExec(tc, testNamespace, s.clientPod, "")
-	err := smbclient.CacheFlush(ctx)
-	s.Require().NoError(err)
+	client := smbclient.MustPodExec(tc, testNamespace, s.clientPod, "")
+	err := client.CacheFlush(ctx)
+	require.NoError(err)
+
+	ctx2, cancel := context.WithTimeout(ctx, loginTestTimeout)
+	defer cancel()
 	for _, auth := range s.auths {
-		err := smbclient.Command(
-			ctx,
-			s.share,
-			auth,
-			[]string{"ls"})
-		s.Require().NoError(err)
+		var cmderr error
+		err := poll.TryUntil(ctx2, &poll.Prober{
+			RetryInterval: loginTestInterval,
+			Cond: func() (bool, error) {
+				cmderr = client.Command(
+					ctx,
+					s.share,
+					auth,
+					[]string{"ls"})
+				return cmderr == nil, nil
+			},
+		})
+		// first check that cmderr is nil in order to capture the (much more
+		// relevant) error that client.Command returned. if cmderr == nil
+		// then err == nil. checking err at all is just a belt-and-suspenders
+		// extra check in case something unexpected happens.
+		require.NoError(cmderr)
+		require.NoError(err)
 	}
 }
 

--- a/tests/integration/share_access_test.go
+++ b/tests/integration/share_access_test.go
@@ -84,17 +84,17 @@ func (s *ShareAccessSuite) TestLogin() {
 func (s *ShareAccessSuite) TestPutFile() {
 	ctx := s.defaultContext()
 	tc := kube.NewTestClient("")
-	smbclient := smbclient.MustPodExec(tc, testNamespace, s.clientPod, "")
-	err := smbclient.CacheFlush(ctx)
+	client := smbclient.MustPodExec(tc, testNamespace, s.clientPod, "")
+	err := client.CacheFlush(ctx)
 	s.Require().NoError(err)
 	auth := s.auths[0]
-	err = smbclient.Command(
+	err = client.Command(
 		ctx,
 		s.share,
 		auth,
 		[]string{"put profile.jpeg"})
 	s.Require().NoError(err)
-	out, err := smbclient.CommandOutput(
+	out, err := client.CommandOutput(
 		ctx,
 		s.share,
 		auth,


### PR DESCRIPTION
Depends on: #225

Attempt smbclient logins in a retry loop to guard against minor timing differences between pod ready and smbclient working.