### PR TITLE
smbcc: Add 'dos charset' option to Global smb.conf defaults

### DIFF
--- a/internal/smbcc/container_config.go
+++ b/internal/smbcc/container_config.go
@@ -148,6 +148,7 @@ func NewGlobals(opts GlobalOptions) GlobalConfig {
 			"printing":        "bsd",
 			"printcap name":   "/dev/null",
 			"disable spoolss": Yes,
+			"dos charset":     "ascii",
 			"smb ports":       strconv.Itoa(opts.SmbPort),
 		},
 	}


### PR DESCRIPTION
`dos charset` option allows us to specify a particular charset which in turn helps to avoid the following warning message on clients in the absence of 850 charset:

> dos charset 'CP850' unavailable - using ASCII