### PR TITLE
Break Update reconcile function into smaller parts

### DIFF
--- a/internal/resources/result.go
+++ b/internal/resources/result.go
@@ -31,6 +31,11 @@ func (r Result) Requeue() bool {
 	return r.requeue
 }
 
+// Yield returns true if current processing should be discontinued.
+func (r Result) Yield() bool {
+	return r.requeue || r.err != nil
+}
+
 var (
 	// Done represents a result that is complete.
 	Done = Result{}


### PR DESCRIPTION
First, we add a Yield method that will return true if the result's content indicates that no further processing should be done.

Then using the Result.Yield method, we can more easily separate parts of the rather large Update function into sub-routines each returning `Done` if that sub-routine has nothing else to do or setting an error or requesting a `Requeue`.

View with -w (ignore whitespace) as well as default to see that most of this patch is moving chunks of Update into new functions.


I think this is a nice small tweak on the existing Result type that enables building "nested" reconcile functions. I'm throwing ths out there as a Draft first to see what you think.

Depends on: #239 