### PR TITLE
Add comments to some packages

### DIFF
--- a/controllers/smbshare_controller.go
+++ b/controllers/smbshare_controller.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package controllers defines this operator's controllers.
 package controllers
 
 import (

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -1,3 +1,4 @@
+// Package conf defines the operator's configuration parameters.
 package conf
 
 import (

--- a/internal/planner/doc.go
+++ b/internal/planner/doc.go
@@ -1,0 +1,2 @@
+// Package planner helps determine the desired state.
+package planner

--- a/internal/resources/doc.go
+++ b/internal/resources/doc.go
@@ -1,0 +1,2 @@
+// Package resources works directly with k8s resources.
+package resources

--- a/internal/smbcc/doc.go
+++ b/internal/smbcc/doc.go
@@ -1,0 +1,2 @@
+// Package smbcc manages sambacc JSON configuration.
+package smbcc

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Command to start the samba-operator.
 package main
 
 import (

--- a/tests/utils/kube/doc.go
+++ b/tests/utils/kube/doc.go
@@ -1,0 +1,2 @@
+// Package kube contains kubernetes utility functions for tests.
+package kube

--- a/tests/utils/poll/poll.go
+++ b/tests/utils/poll/poll.go
@@ -1,3 +1,4 @@
+// Package poll assists in writing polling loops.
 package poll
 
 import (

--- a/tests/utils/smbclient/smbclient.go
+++ b/tests/utils/smbclient/smbclient.go
@@ -1,3 +1,4 @@
+// Package smbclient is used to execute smbclient commands.
 package smbclient
 
 import (


### PR DESCRIPTION
This will fix errors detected by revive as part of running `make check`.
It's genuinely a good thing to have docs, but in some cases they could use a little fleshing out.