### PR TITLE
dockerfile: use ubi9 as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} GO111MODULE=on \
     -ldflags "-X main.Version=${GIT_VERSION} -X main.CommitID=${COMMIT_ID}" \
     -o manager main.go
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 WORKDIR /
 COPY --from=builder /workspace/manager .


### PR DESCRIPTION
Use Red Hat's Universal Base Image 9 (ubi9) for samba-operator.

Signed-off-by: Shachar Sharon <ssharon@redhat.com>