### PR TITLE
tests/integration: Fix issues reported by `gofmt`

### DIFF
--- a/tests/integration/path_permissions.go
+++ b/tests/integration/path_permissions.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package integration

--- a/tests/integration/resource_update_test.go
+++ b/tests/integration/resource_update_test.go
@@ -1,5 +1,6 @@
 //go:build integration
 // +build integration
+
 // SPDX-License-Identifier: Apache-2.0
 
 package integration


### PR DESCRIPTION
Following diff was suggested as a result of `gofmt` execution:

```
# go version
go version go1.18.4 linux/amd64

# gofmt -d -e -s -l .
tests/integration/path_permissions.go
diff -u tests/integration/path_permissions.go.orig tests/integration/path_permissions.go
--- tests/integration/path_permissions.go.orig	2022-08-31 21:40:37.504171615 +0530
+++ tests/integration/path_permissions.go	2022-08-31 21:40:37.504171615 +0530
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package integration
tests/integration/resource_update_test.go
diff -u tests/integration/resource_update_test.go.orig tests/integration/resource_update_test.go
--- tests/integration/resource_update_test.go.orig	2022-08-31 21:40:37.507171634 +0530
+++ tests/integration/resource_update_test.go	2022-08-31 21:40:37.507171634 +0530
@@ -1,5 +1,6 @@
 //go:build integration
 // +build integration
+
 // SPDX-License-Identifier: Apache-2.0
 
 package integration
```