### PR TITLE
controllers: removed unused Scheme field

### DIFF
--- a/controllers/smbcommonconfig_controller.go
+++ b/controllers/smbcommonconfig_controller.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	"github.com/go-logr/logr"
-	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -33,7 +32,6 @@ import (
 type SmbCommonConfigReconciler struct {
 	client.Client
 	Log         logr.Logger
-	Scheme      *runtime.Scheme
 	ClusterType resources.ClusterType
 }
 

--- a/controllers/smbsecurityconfig_controller.go
+++ b/controllers/smbsecurityconfig_controller.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	"github.com/go-logr/logr"
-	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -30,8 +29,7 @@ import (
 // SmbSecurityConfigReconciler reconciles a SmbSecurityConfig object
 type SmbSecurityConfigReconciler struct {
 	client.Client
-	Log    logr.Logger
-	Scheme *runtime.Scheme
+	Log logr.Logger
 }
 
 //revive:disable kubebuilder directives


### PR DESCRIPTION
Having an unused and uninitialized 'Scheme' member to SmbCommonConfigReconciler is confusing; a naive user may assume that it is set to non-nil reference which end with run-time panic.

Signed-off-by: Shachar Sharon <ssharon@redhat.com>