### PR TITLE
build: fix minor 'make check' error with go1.19

### DIFF
--- a/internal/resources/metrics.go
+++ b/internal/resources/metrics.go
@@ -11,7 +11,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/types" // nolint:typecheck
 	"k8s.io/apimachinery/pkg/util/intstr"
 	rtclient "sigs.k8s.io/controller-runtime/pkg/client"
 


### PR DESCRIPTION
Fixed minor lint error when compiling the code with go1.19 (amd64, Fedora35).

Signed-off-by: Shachar Sharon <ssharon@redhat.com>