### PR TITLE
hack: update to golangci-lint v1.49.0

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -5,7 +5,7 @@ linters:
   disable-all: true
   enable:
     - asciicheck
-    - deadcode
+    # - deadcode
     - depguard
     - dupl
     - errcheck
@@ -30,14 +30,14 @@ linters:
     # - nolintlint
     - revive
     - staticcheck
-    - structcheck
+    # - structcheck
     # - tagliatelle
     # - testpackage
     - typecheck
     - unconvert
     # - unparam
     - unused
-    - varcheck
+    # - varcheck
     - whitespace
 linters-settings:
   funlen:

--- a/hack/install-tools.sh
+++ b/hack/install-tools.sh
@@ -29,7 +29,7 @@ _install_revive() {
 }
 
 _install_golangci_lint() {
-	_install_tool github.com/golangci/golangci-lint/cmd/golangci-lint@v1.43.0
+	_install_tool github.com/golangci/golangci-lint/cmd/golangci-lint@v1.49.0
 }
 
 _install_yq() {

--- a/internal/planner/configuration.go
+++ b/internal/planner/configuration.go
@@ -81,11 +81,11 @@ func (pl *Planner) idmapOptions() smbcc.SmbOptions {
 // Update the held configuration based on the state of the instance
 // configuration.
 func (pl *Planner) Update() (changed bool, err error) {
-	globals, found := pl.ConfigState.Globals[smbcc.Globals]
+	_, found := pl.ConfigState.Globals[smbcc.Globals]
 	if !found {
 		globalOptions := smbcc.NewGlobalOptions()
 		globalOptions.SmbPort = pl.GlobalConfig.SmbdPort
-		globals = smbcc.NewGlobals(globalOptions)
+		globals := smbcc.NewGlobals(globalOptions)
 		pl.ConfigState.Globals[smbcc.Globals] = globals
 		changed = true
 	}


### PR DESCRIPTION
Use newer version of golangci-lint. Disabled linters which are defined as deprecated or unmaintained (namely: deadcode, structcheck and varcheck).

Fixed newly discovered trivial case of assigned-but-unused variable in configuration.go.

Signed-off-by: Shachar Sharon <ssharon@redhat.com>