### PR TITLE
planner: fixed set-but-not-used assignment

### DIFF
--- a/internal/planner/configuration.go
+++ b/internal/planner/configuration.go
@@ -81,11 +81,11 @@ func (pl *Planner) idmapOptions() smbcc.SmbOptions {
 // Update the held configuration based on the state of the instance
 // configuration.
 func (pl *Planner) Update() (changed bool, err error) {
-	globals, found := pl.ConfigState.Globals[smbcc.Globals]
+	_, found := pl.ConfigState.Globals[smbcc.Globals]
 	if !found {
 		globalOptions := smbcc.NewGlobalOptions()
 		globalOptions.SmbPort = pl.GlobalConfig.SmbdPort
-		globals = smbcc.NewGlobals(globalOptions)
+		globals := smbcc.NewGlobals(globalOptions)
 		pl.ConfigState.Globals[smbcc.Globals] = globals
 		changed = true
 	}


### PR DESCRIPTION
Fixed minor dead-assigment to use un-named variable. Detected by golangci-lint v1.49, which requires go1.19.

Signed-off-by: Shachar Sharon <ssharon@redhat.com>