### PR TITLE
explicit tools versions

### DIFF
--- a/hack/install-tools.sh
+++ b/hack/install-tools.sh
@@ -33,7 +33,7 @@ _install_golangci_lint() {
 }
 
 _install_yq() {
-	_install_tool github.com/mikefarah/yq/v4@latest
+	_install_tool github.com/mikefarah/yq/v4@v4.23.1
 }
 
 case "$1" in

--- a/hack/install-tools.sh
+++ b/hack/install-tools.sh
@@ -29,7 +29,7 @@ _install_revive() {
 }
 
 _install_golangci_lint() {
-	_install_tool github.com/golangci/golangci-lint/cmd/golangci-lint@v1.43.0
+	_install_tool github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.2
 }
 
 _install_yq() {

--- a/hack/install-tools.sh
+++ b/hack/install-tools.sh
@@ -25,7 +25,7 @@ _install_controller_gen() {
 }
 
 _install_revive() {
-	_install_tool github.com/mgechev/revive@latest
+	_install_tool github.com/mgechev/revive@v1.2.3
 }
 
 _install_golangci_lint() {


### PR DESCRIPTION
Currently, samba-operator supports as far back as Go1.16 (e.g., in github actions). However, not all our build tools are compatible with this version in their latest release. Thus, we need to pin-point each tool to explicit version which is not too old but still supports Go1.16. 