### PR TITLE
controllers: set controller watches on owned configmaps & statefulsets

### DIFF
--- a/controllers/smbshare_controller.go
+++ b/controllers/smbshare_controller.go
@@ -83,6 +83,9 @@ func (r *SmbShareReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&sambaoperatorv1alpha1.SmbShare{}).
 		Owns(&corev1.PersistentVolumeClaim{}).
+		Owns(&corev1.ConfigMap{}).
+		Owns(&corev1.Service{}).
 		Owns(&appsv1.Deployment{}).
+		Owns(&appsv1.StatefulSet{}).
 		Complete(r)
 }


### PR DESCRIPTION
When a configmap or statefulset is created by the operator in response to an SmbShare resource, we set the SmbShare as the owner (controller owner). We want our reconcile loop to be called when a change is made to one of these resources.