### PR TITLE
resources: fix config update container creating missing share dirs

### DIFF
--- a/internal/resources/pods.go
+++ b/internal/resources/pods.go
@@ -427,10 +427,13 @@ func buildSmbdCtrs(
 	ctrs := []corev1.Container{}
 	ctrs = append(ctrs, buildSmbdCtr(planner, env, vols))
 	metaOnlyVols := vols.exclude(tagData)
-	// insert a container to watch for changes to the config json
-	// and apply those changes to samba
+	// Insert a container to watch for changes to the config json
+	// and apply those changes to samba.
+	// We need to pass data vols to the config update container as it is
+	// responsible for creating missing dirs and setting perms when new shares
+	// appear.
 	ctrs = append(ctrs, buildUpdateConfigWatchCtr(
-		planner, env, metaOnlyVols))
+		planner, env, vols))
 	if withMetricsExporter(planner.GlobalConfig) {
 		ctrs = append(ctrs, buildSmbdMetricsCtr(
 			planner, metaPodEnv(), metaOnlyVols))


### PR DESCRIPTION
The configuration update container will create missing share directories if they don't exist (as well as setting up initial perms). However, this will not work if the container doesn't have access to the data volume. Give the container access to the data volume.
