### PR TITLE
tests: Raise timeout for clustered test runs

### DIFF
--- a/tests/test.sh
+++ b/tests/test.sh
@@ -10,7 +10,7 @@ export PATH=${PATH}:${LOCAL_BINDIR}
 
 gtest() {
     if [ "$SMBOP_TEST_CLUSTERED" ]; then
-        go test -tags integration -v -count 1 -timeout 20m "$@"
+        go test -tags integration -v -count 1 -timeout 30m "$@"
     else
         go test -tags integration -v -count 1 "$@"
     fi


### PR DESCRIPTION
This is the second time we are increasing the overall test time for integration test run. With new tests being added and recent fixes to existing tests it is in our best interest to increase further by 10 minutes.