### PR TITLE
planner: add Prune function to remove shares

### DIFF
--- a/internal/planner/configuration_test.go
+++ b/internal/planner/configuration_test.go
@@ -26,6 +26,18 @@ func TestUpdate(t *testing.T) {
 	})
 }
 
+func TestPrune(t *testing.T) {
+	t.Run("addTwoPruneOne", func(t *testing.T) {
+		testAddTwoPruneOne(t, smbcc.New())
+	})
+	t.Run("addTwoPruneTwo", func(t *testing.T) {
+		testAddTwoPruneTwo(t, smbcc.New())
+	})
+	t.Run("addTwoPruneSame", func(t *testing.T) {
+		testAddTwoPruneSame(t, smbcc.New())
+	})
+}
+
 func sampleSmbShare1() *sambaoperatorv1alpha1.SmbShare {
 	return &sambaoperatorv1alpha1.SmbShare{
 		ObjectMeta: metav1.ObjectMeta{
@@ -189,4 +201,59 @@ func testADShare(t *testing.T, state *smbcc.SambaContainerConfig) {
 	assert.Contains(t, state.Shares, smbcc.Key("share3"))
 	assert.Contains(t, state.Configs[p.instanceID()].Shares, smbcc.Key("share3"))
 	assert.Contains(t, state.Globals, smbcc.Key("FOO.TEST"))
+}
+
+func testAddTwoPruneOne(t *testing.T, state *smbcc.SambaContainerConfig) {
+	testSecondShare(t, state)
+
+	p := New(InstanceConfiguration{
+		SmbShare:     sampleSmbShare1(),
+		GlobalConfig: &conf.OperatorConfig{},
+	}, state)
+	changed, err := p.Prune()
+	assert.NoError(t, err)
+	assert.True(t, changed)
+
+	assert.Len(t, state.Shares, 1)
+	assert.Len(t, state.Configs, 1)
+	assert.Len(t, state.Globals, 1)
+	assert.Contains(t, state.Shares, smbcc.Key("share2"))
+	assert.Contains(t, state.Configs[p.instanceID()].Shares, smbcc.Key("share2"))
+	assert.NotContains(t, state.Configs[p.instanceID()].Shares, smbcc.Key("share1"))
+}
+
+func testAddTwoPruneTwo(t *testing.T, state *smbcc.SambaContainerConfig) {
+	testAddTwoPruneOne(t, state)
+
+	p := New(InstanceConfiguration{
+		SmbShare:     sampleSmbShare2(),
+		GlobalConfig: &conf.OperatorConfig{},
+	}, state)
+	changed, err := p.Prune()
+	assert.NoError(t, err)
+	assert.True(t, changed)
+
+	assert.Len(t, state.Shares, 0)
+	assert.Len(t, state.Configs, 1)
+	assert.Len(t, state.Globals, 1)
+	assert.NotContains(t, state.Configs[p.instanceID()].Shares, smbcc.Key("share1"))
+	assert.NotContains(t, state.Configs[p.instanceID()].Shares, smbcc.Key("share2"))
+}
+
+func testAddTwoPruneSame(t *testing.T, state *smbcc.SambaContainerConfig) {
+	testAddTwoPruneOne(t, state)
+
+	p := New(InstanceConfiguration{
+		SmbShare:     sampleSmbShare1(),
+		GlobalConfig: &conf.OperatorConfig{},
+	}, state)
+	changed, err := p.Prune()
+	assert.NoError(t, err)
+	assert.False(t, changed)
+
+	assert.Len(t, state.Shares, 1)
+	assert.Len(t, state.Configs, 1)
+	assert.Len(t, state.Globals, 1)
+	assert.NotContains(t, state.Configs[p.instanceID()].Shares, smbcc.Key("share1"))
+	assert.Contains(t, state.Configs[p.instanceID()].Shares, smbcc.Key("share2"))
 }


### PR DESCRIPTION
Nothing uses this change yet, but it adds a function to the internal planner
library to Prune shares from an otherwise populated smbcc config.
Once the operator supports adding multiple shares to one instance we'll also
need a way to remove them.

With unit tests.