### PR TITLE
tests: raise timeout of non-clustered tests to 20m

### DIFF
--- a/tests/test.sh
+++ b/tests/test.sh
@@ -12,7 +12,7 @@ gtest() {
     if [ "$SMBOP_TEST_CLUSTERED" ]; then
         go test -tags integration -v -count 1 -timeout 30m "$@"
     else
-        go test -tags integration -v -count 1 "$@"
+        go test -tags integration -v -count 1 -timeout 20m "$@"
     fi
 }
 


### PR DESCRIPTION
As we add more and more test cases we're getting closer to timing out on the non clustered suites. Bump the limit so this is less of a risk even on slower setups.

Signed-off-by: John Mulligan <jmulligan@redhat.com>