### PR TITLE
planner: add functions to check if smbshares are compatible 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,8 @@ require (
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.46.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.1
-	github.com/stretchr/testify v1.7.0
+	github.com/stretchr/testify v1.8.0
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.22.2
 	k8s.io/apimachinery v0.22.2
 	k8s.io/client-go v0.22.2
@@ -64,7 +65,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.51.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.22.2 // indirect
 	k8s.io/component-base v0.22.2 // indirect
 	k8s.io/klog/v2 v2.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -498,13 +498,16 @@ github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=

--- a/internal/planner/compatible.go
+++ b/internal/planner/compatible.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package planner
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// IncompatibleInstanceError indicates SmbShare resources are not compatible
+// with each other and can not hosted by the same server.
+type IncompatibleInstanceError struct {
+	current  string
+	existing string
+	reason   string
+}
+
+// Error interface method.
+func (iie IncompatibleInstanceError) Error() string {
+	return fmt.Sprintf("Share resource %s is incompatible with %s: %s",
+		iie.current,
+		iie.existing,
+		iie.reason)
+}
+
+func incompatible(
+	current, existing InstanceConfiguration,
+	reason string) IncompatibleInstanceError {
+	// ---
+	return IncompatibleInstanceError{
+		current:  current.SmbShare.Name,
+		existing: existing.SmbShare.Name,
+		reason:   reason,
+	}
+}
+
+// CheckCompatible returns an error if the instance configurations are
+// not compatible with each other. A compatible instance is one that
+// can share the same smbd.
+func CheckCompatible(current, existing InstanceConfiguration) error {
+	// This returns an error rather than a boolean because in the future
+	// we can choose to add details about what is incompatible to
+	// the specific error type.
+	if current.SmbShare == nil || existing.SmbShare == nil {
+		name1, name2 := "<invalid>", "<invalid>"
+		if current.SmbShare != nil {
+			name1 = current.SmbShare.Name
+		}
+		if existing.SmbShare != nil {
+			name2 = existing.SmbShare.Name
+		}
+		return IncompatibleInstanceError{
+			current:  name1,
+			existing: name2,
+			reason:   "instance configuration missing SmbShare",
+		}
+	}
+
+	if current.SmbShare.Namespace != existing.SmbShare.Namespace {
+		return incompatible(current, existing, "namespaces differ")
+	}
+	if current.SmbShare.Spec.Storage.Pvc.Name != existing.SmbShare.Spec.Storage.Pvc.Name {
+		return incompatible(current, existing,
+			"PersistentVolumeClaim name mismatch")
+	}
+	if current.SmbShare.Spec.SecurityConfig != existing.SmbShare.Spec.SecurityConfig {
+		return incompatible(current, existing,
+			"security config name mismatch")
+	}
+	if current.SmbShare.Spec.CommonConfig != existing.SmbShare.Spec.CommonConfig {
+		return incompatible(current, existing,
+			"common config name mismatch")
+	}
+
+	// additional checks
+	var uid1, uid2 types.UID
+	if current.SecurityConfig != nil {
+		uid1 = current.SecurityConfig.UID
+	}
+	if existing.SecurityConfig != nil {
+		uid2 = existing.SecurityConfig.UID
+	}
+	if uid1 != uid2 {
+		return incompatible(current, existing,
+			"security configuration resources differ")
+	}
+
+	uid1, uid2 = "", ""
+	if current.CommonConfig != nil {
+		uid1 = current.CommonConfig.UID
+	}
+	if existing.CommonConfig != nil {
+		uid2 = existing.CommonConfig.UID
+	}
+	if uid1 != uid2 {
+		return incompatible(current, existing,
+			"common configuration resources differ")
+	}
+
+	return nil
+}

--- a/internal/planner/compatible_test.go
+++ b/internal/planner/compatible_test.go
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package planner
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	sambaoperatorv1alpha1 "github.com/samba-in-kubernetes/samba-operator/api/v1alpha1"
+)
+
+func phonyInstanceConfiguration() InstanceConfiguration {
+	ic1 := InstanceConfiguration{
+		SmbShare: &sambaoperatorv1alpha1.SmbShare{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "share1",
+				Namespace: "smbshares",
+				UID:       "phonyuid1",
+			},
+			Spec: sambaoperatorv1alpha1.SmbShareSpec{
+				ShareName:      "share1",
+				ReadOnly:       false,
+				Browseable:     true,
+				SecurityConfig: "myusers1",
+				CommonConfig:   "mycommon1",
+				Storage: sambaoperatorv1alpha1.SmbShareStorageSpec{
+					Pvc: &sambaoperatorv1alpha1.SmbSharePvcSpec{
+						Name: "mydata",
+						Path: "share1",
+					},
+				},
+			},
+		},
+	}
+	return ic1
+}
+
+func phonyInstanceConfiguration2(ns, security, common, pvcname string) InstanceConfiguration {
+	ic2 := InstanceConfiguration{
+		SmbShare: &sambaoperatorv1alpha1.SmbShare{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "share2",
+				Namespace: ns,
+				UID:       "phonyuid2",
+			},
+			Spec: sambaoperatorv1alpha1.SmbShareSpec{
+				ShareName:      "share2",
+				ReadOnly:       false,
+				Browseable:     false,
+				SecurityConfig: security,
+				CommonConfig:   common,
+				Storage: sambaoperatorv1alpha1.SmbShareStorageSpec{
+					Pvc: &sambaoperatorv1alpha1.SmbSharePvcSpec{
+						Name: pvcname,
+						Path: "share2",
+					},
+				},
+			},
+		},
+	}
+	return ic2
+}
+
+func TestCheckCompatible(t *testing.T) {
+	ic1 := phonyInstanceConfiguration()
+
+	t.Run("compatible", func(t *testing.T) {
+		ic2 := phonyInstanceConfiguration2("smbshares", "myusers1", "mycommon1", "mydata")
+		assert.NoError(t, CheckCompatible(ic1, ic2))
+	})
+
+	t.Run("invalidShares", func(t *testing.T) {
+		icx := InstanceConfiguration{}
+		err := CheckCompatible(icx, icx)
+		if assert.Error(t, err) {
+			iie := err.(IncompatibleInstanceError)
+			assert.Equal(t, iie.current, "<invalid>")
+			assert.Equal(t, iie.existing, "<invalid>")
+		}
+	})
+	t.Run("invalidExisting", func(t *testing.T) {
+		icx := InstanceConfiguration{}
+		err := CheckCompatible(icx, ic1)
+		if assert.Error(t, err) {
+			iie := err.(IncompatibleInstanceError)
+			assert.Equal(t, iie.current, "<invalid>")
+			assert.Equal(t, iie.existing, "share1")
+		}
+	})
+	t.Run("invalidCurrent", func(t *testing.T) {
+		icx := InstanceConfiguration{}
+		err := CheckCompatible(ic1, icx)
+		if assert.Error(t, err) {
+			iie := err.(IncompatibleInstanceError)
+			assert.Equal(t, iie.current, "share1")
+			assert.Equal(t, iie.existing, "<invalid>")
+		}
+	})
+
+	t.Run("differentNamespace", func(t *testing.T) {
+		ic2 := phonyInstanceConfiguration2("whoopsie", "myusers1", "mycommon1", "mydata")
+		err := CheckCompatible(ic1, ic2)
+		if assert.Error(t, err) {
+			assert.ErrorContains(t, err, "namespaces")
+		}
+	})
+
+	t.Run("differentPVC", func(t *testing.T) {
+		ic2 := phonyInstanceConfiguration2("smbshares", "myusers1", "mycommon1", "foobar")
+		err := CheckCompatible(ic1, ic2)
+		if assert.Error(t, err) {
+			assert.ErrorContains(t, err, "PersistentVolumeClaim name")
+		}
+	})
+
+	t.Run("differentSecurityConfig", func(t *testing.T) {
+		ic2 := phonyInstanceConfiguration2("smbshares", "xxxxx", "mycommon1", "mydata")
+		err := CheckCompatible(ic1, ic2)
+		if assert.Error(t, err) {
+			assert.ErrorContains(t, err, "security config name")
+		}
+	})
+
+	t.Run("differentCommonConfig", func(t *testing.T) {
+		ic2 := phonyInstanceConfiguration2("smbshares", "myusers1", "zzzzz", "mydata")
+		err := CheckCompatible(ic1, ic2)
+		if assert.Error(t, err) {
+			assert.ErrorContains(t, err, "common config name")
+		}
+	})
+}


### PR DESCRIPTION
Compatible SmbShares are shares that can be hosted by one smbd instance.
In other words, compatible share can be grouped together. This function
is not yet used but will be once we have the ability to specify grouped
smbshares.

Adds a newer version of testify and matching unit tests. 