### PR TITLE
integration tests: test SmbShares enabling grouping and clustering 

### DIFF
--- a/tests/files/cross-pvc2.yaml
+++ b/tests/files/cross-pvc2.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cross-pvc2
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 100Mi
+  volumeMode: Filesystem

--- a/tests/files/cross-share1ctdb.yaml
+++ b/tests/files/cross-share1ctdb.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: samba-operator.samba.org/v1alpha1
+kind: SmbShare
+metadata:
+  name: cross-share1ctdb
+  annotations:
+    samba-operator.samba.org/node-spread: "false"
+spec:
+  shareName: "Ecks Cee One"
+  readOnly: false
+  browseable: true
+  securityConfig: sharesec1
+  scaling:
+    availabilityMode: clustered
+    minClusterSize: 3
+    groupMode: explicit
+    group: cross-clust
+  storage:
+    pvc:
+      name: cross-pvc2
+      path: one

--- a/tests/files/cross-share2ctdb.yaml
+++ b/tests/files/cross-share2ctdb.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: samba-operator.samba.org/v1alpha1
+kind: SmbShare
+metadata:
+  name: cross-share2ctdb
+  annotations:
+    samba-operator.samba.org/node-spread: "false"
+spec:
+  shareName: "Ecks Cee Two"
+  readOnly: false
+  browseable: true
+  securityConfig: sharesec1
+  scaling:
+    availabilityMode: clustered
+    minClusterSize: 3
+    groupMode: explicit
+    group: cross-clust
+  storage:
+    pvc:
+      name: cross-pvc2
+      path: two

--- a/tests/integration/share_access_test.go
+++ b/tests/integration/share_access_test.go
@@ -103,6 +103,7 @@ func requireSMBLogin(
 		err := poll.TryUntil(ctx2, &poll.Prober{
 			RetryInterval: loginTestInterval,
 			Cond: func() (bool, error) {
+				_ = client.CacheFlush(ctx)
 				cmderr = client.Command(
 					ctx,
 					share,

--- a/tests/integration/share_access_test.go
+++ b/tests/integration/share_access_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	loginTestTimeout  = 10 * time.Second
+	loginTestTimeout  = 30 * time.Second
 	loginTestInterval = 500 * time.Millisecond
 )
 


### PR DESCRIPTION
Depends on #240 

This series is really two parts: first it fixes some test flakiness I was seeing on my local system. The CI wasn't being as flaky but I think these changes will make it more reliable too. Second, I add one additional test case to verify that combining the two SmbShare scaling modes, grouping and clustering, can work properly together.
