### PR TITLE
workflows: build within emulated container

### DIFF
--- a/.github/workflows/build-within-container.yml
+++ b/.github/workflows/build-within-container.yml
@@ -1,0 +1,26 @@
+name: Build within container
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+jobs:
+  build-within-container:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Enable emulation
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu qemu-user-static
+          sudo update-binfmts --display
+      - name: Require build utilities
+        run: |
+          command -v podman
+          command -v qemu-x86_64-static
+          command -v qemu-aarch64-static
+      - name: Build within AMD64 container
+        run: hack/build-within-container.sh amd64
+      - name: Build within ARM64 container
+        run: hack/build-within-container.sh arm64

--- a/hack/Dockerfile.build
+++ b/hack/Dockerfile.build
@@ -1,0 +1,8 @@
+FROM centos:stream9
+WORKDIR /workspace
+RUN dnf install -y epel-release epel-next-release
+RUN dnf install -y gcc tar golang wget make yamllint
+COPY samba-operator.tar.gz .
+RUN tar xvfz samba-operator.tar.gz
+RUN go version
+RUN make

--- a/hack/build-within-container.sh
+++ b/hack/build-within-container.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+export LC_ALL=C
+unset CDPATH
+ARCH=${1:-amd64}
+
+# Currently, aupport amd64 (x86_64) and arm64 (aarch64) architectures
+case "${ARCH}" in "amd64") ;; "arm64") ;; \
+	*) echo "illegal ${ARCH}" && exit 1 ;; esac
+
+# Prerequisites checks
+_require_command() {
+	command -v "$1" > /dev/null || (echo "missing: $1" && exit 1)
+}
+
+_require_command realpath
+_require_command git
+_require_command podman
+_require_command qemu-x86_64-static
+_require_command qemu-aarch64-static
+
+# Fail on error
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Create tar-ball using git
+BASEDIR=$(realpath "$(dirname "${BASH_SOURCE[0]}")/../")
+cd "${BASEDIR}"
+git archive --format tar.gz HEAD > hack/samba-operator.tar.gz
+function cleanup_on_exit() { rm -f hack/samba-operator.tar.gz; }
+trap cleanup_on_exit EXIT
+
+# Build within container using podman
+podman build \
+  --arch=${ARCH} \
+  --tag localhost/samba-operator-build:${ARCH} \
+  --file hack/Dockerfile.build


### PR DESCRIPTION
Use QEMU to build samba-operator within containerized environment; either AMD64 or ARM64 architectures (regardless of local host architecture). Using this method we can ensures that all build tools are properly configured on architectures other than default x86_64, without relaying on specific hardware.

Signed-off-by: Shachar Sharon <ssharon@redhat.com>