### PR TITLE
dockerfile: add image annotations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,9 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} GO111MODULE=on \
     -o manager main.go
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+LABEL org.opencontainers.image.title="Samba operator"
+LABEL org.opencontainers.image.vendor="Samba in Kubernetes"
+LABEL org.opencontainers.image.url="https://github.com/samba-in-kubernetes/samba-operator"
 
 WORKDIR /
 COPY --from=builder /workspace/manager .


### PR DESCRIPTION
Use standard image-spec annotations[1] to define minimal reference to SINK project within the samba-operator image itself.

[1] https://github.com/opencontainers/image-spec/blob/main/annotations.md

Signed-off-by: Shachar Sharon <ssharon@redhat.com>