### PR TITLE
github: fix indentation in mergify config yaml

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -62,10 +62,10 @@ pull_request_rules:
           - "#approved-reviews-by>=2"
           # A maintainer's contribution only needs 1 review BUT we give a grace
           # period over just two weeks for a 2nd reviewer to hopefully appear.
-      - and:
-          - "updated-at<15 days ago"
-          - "author=@maintainers"
-          - "#approved-reviews-by>=1"
+          - and:
+              - "updated-at<15 days ago"
+              - "author=@maintainers"
+              - "#approved-reviews-by>=1"
     actions:
       queue: {}
       dismiss_reviews: {}


### PR DESCRIPTION
The rule is supposed to be merge if two reviews OR if "change posted by a maintainer with one review after two weeks". It was accidentally requiring the latter for all PRs.

One can review YAML and still miss stuff like this :-)