### PR TITLE
makefile: allow override KUBECTL_CMD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ endif
 
 GO_CMD:=go
 GOFMT_CMD:=gofmt
-KUBECTL_CMD:=kubectl
+KUBECTL_CMD?=kubectl
 BUILDAH_CMD:=buildah
 YAMLLINT_CMD:=yamllint
 

--- a/devel.mk.sample
+++ b/devel.mk.sample
@@ -7,6 +7,9 @@ VERSION=0.0.1
 # Run in developer mode
 DEVELOPER=1
 
+# Use OpenShift's Client CLI
+# KUBECTL_CMD=oc
+
 # Image URL to use all building/pushing image targets
 TAG=latest
 IMG=quay.io/quayusername/samba-operator:$(TAG)


### PR DESCRIPTION
When (developer is) running over OpenShift cluster it is typical to use the OpenShift Client CLI (oc[1]) utility instead of kubectl. Allow her to override Makefile's KUBECTL_CMD.

[1] https://github.com/openshift/oc

Signed-off-by: Shachar Sharon <ssharon@redhat.com>