### PR TITLE
github: Update CentOS CI status check for Mergify

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -20,7 +20,7 @@ queue_rules:
       - check-success=dockerbuild
       - check-success=test
       - check-success=test-kubernetes
-      - check-success=centos-ci/sink-clustered/mini-k8s-1.25
+      - check-success=centos-ci/sink-clustered/mini-k8s-1.26
       - check-success=dpulls
 
 
@@ -42,7 +42,7 @@ pull_request_rules:
       - check-success=dockerbuild
       - check-success=test
       - check-success=test-kubernetes
-      - check-success=centos-ci/sink-clustered/mini-k8s-1.25
+      - check-success=centos-ci/sink-clustered/mini-k8s-1.26
       - check-success=dpulls
       - "-draft"
       # Contributors should set the 'do-not-merge' label if they don't want


### PR DESCRIPTION
We recently [updated](https://github.com/anoopcs9/samba-centosci/commit/89e79079a2988e1b2ea39b9b4a5e1d50541206ae) our CI job on CentOS infra to consume Kuberentes v1.26. Therefore update the corresponding status check in Mergify configuration to indicate new version.