### PR TITLE
add default node selector value and configuration

### DIFF
--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -24,6 +24,7 @@ var DefaultOperatorConfig = OperatorConfig{
 	SmbdPort:                  445,
 	MetricsExporterMode:       "disabled",
 	ImagePullPolicy:           "IfNotPresent",
+	DefaultNodeSelector:       "",
 }
 
 // OperatorConfig is a type holding general configuration values.
@@ -78,6 +79,10 @@ type OperatorConfig struct {
 	// ImagePullPolicy is a (string) value which defines the image-download
 	// strategy of samba containers.
 	ImagePullPolicy string `mapstructure:"image-pull-policy"`
+	// DefaultNodeSelector is a string value containing JSON which defines
+	// a set of key-value pairs that will be used for all default node
+	// selection. If left blank, internal defaults will be used.
+	DefaultNodeSelector string `mapstructure:"default-node-selector"`
 }
 
 // Validate the OperatorConfig returning an error if the config is not
@@ -128,6 +133,7 @@ func NewSource() *Source {
 	v.SetDefault("pod-namespace", d.PodNamespace)
 	v.SetDefault("pod-ip", d.PodIP)
 	v.SetDefault("image-pull-policy", d.ImagePullPolicy)
+	v.SetDefault("default-node-selector", d.DefaultNodeSelector)
 	return &Source{v: v}
 }
 

--- a/internal/planner/selector.go
+++ b/internal/planner/selector.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package planner
+
+import (
+	"encoding/json"
+)
+
+// builtinDefaultNodeSelector defines our defaults if no administrative
+// overrides are supplied. Samba containers run only on linux. Currently
+// they're only built for x86_64 (amd64).
+var builtinDefaultNodeSelector = map[string]string{
+	"kubernetes.io/os":   "linux",
+	"kubernetes.io/arch": "amd64",
+}
+
+// NodeSelector returns a mapping of k8s label names to values that are
+// used to select what nodes resources are scheduled to run on.
+func (pl *Planner) NodeSelector() (map[string]string, error) {
+	if pl.GlobalConfig.DefaultNodeSelector == "" {
+		return builtinDefaultNodeSelector, nil
+	}
+	var nsel map[string]string
+	err := json.Unmarshal([]byte(pl.GlobalConfig.DefaultNodeSelector), &nsel)
+	if err != nil {
+		return builtinDefaultNodeSelector, err
+	}
+	return nsel, nil
+}

--- a/internal/resources/pods.go
+++ b/internal/resources/pods.go
@@ -113,6 +113,8 @@ func buildADPodSpec(
 		buildMustJoinCtr(planner, joinEnv, joinVols),
 	}
 	podSpec.Containers = containers
+	// we have no logger to log the json syntax error to. have to ignore it for now
+	podSpec.NodeSelector, _ = planner.NodeSelector()
 	return podSpec
 }
 
@@ -148,6 +150,8 @@ func buildUserPodSpec(
 	podSpec.Volumes = getVolumes(volumes.all())
 	podSpec.Containers = buildSmbdCtrs(planner, podEnv, volumes)
 	podSpec.InitContainers = initContainers
+	// we have no logger to log the json syntax error to. have to ignore it for now
+	podSpec.NodeSelector, _ = planner.NodeSelector()
 	return podSpec
 }
 
@@ -261,6 +265,8 @@ func buildClusteredUserPodSpec(
 	podSpec.Volumes = getVolumes(volumes.all())
 	podSpec.InitContainers = initContainers
 	podSpec.Containers = containers
+	// we have no logger to log the json syntax error to. have to ignore it for now
+	podSpec.NodeSelector, _ = planner.NodeSelector()
 	return podSpec
 }
 
@@ -416,6 +422,8 @@ func buildClusteredADPodSpec(
 	podSpec.Volumes = getVolumes(volumes.all())
 	podSpec.InitContainers = initContainers
 	podSpec.Containers = containers
+	// we have no logger to log the json syntax error to. have to ignore it for now
+	podSpec.NodeSelector, _ = planner.NodeSelector()
 	return podSpec
 }
 

--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ import (
 	sambaoperatorv1alpha1 "github.com/samba-in-kubernetes/samba-operator/api/v1alpha1"
 	"github.com/samba-in-kubernetes/samba-operator/controllers"
 	"github.com/samba-in-kubernetes/samba-operator/internal/conf"
+	pln "github.com/samba-in-kubernetes/samba-operator/internal/planner"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -96,6 +97,15 @@ func main() {
 		os.Exit(1)
 	}
 	setupLog.Info("loaded configuration successfully", "config", conf.Get())
+
+	planner := pln.New(pln.InstanceConfiguration{
+		GlobalConfig: conf.Get(),
+	}, nil)
+	if _, err := planner.NodeSelector(); err != nil {
+		setupLog.Error(err, "invalid node selector configuration value",
+			"note", "value must be a JSON object containing strings")
+		os.Exit(1)
+	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:             scheme,


### PR DESCRIPTION
Related To: #283

Adds a `default-node-selector` configuration value and some hard coded default values. The hard coded defaults match what samba-container currently provides, images that work on x86_64 linux. Putting a json  mapping in the config allows an admin/dev to customize the defaults without hacking the code or rebuilding the operator (say for example - experimenting with custom build images for arm64).

I plan on following this up with node selectors and affinity support as part of SmbCommonConfig.