### PR TITLE
Deploy on OpenShift with dedicated SCC

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -2,6 +2,12 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
+    app.kubernetes.io/name: samba-operator
+    security.openshift.io/scc.podSecurityLabelSync: "false"
+    pod-security.kubernetes.io/enforce: "privileged"
+    pod-security.kubernetes.io/warn: "privileged"
+    pod-security.kubernetes.io/audit: "privileged"
+    openshift.io/cluster-monitoring: "true"
     control-plane: controller-manager
   name: system
 ---

--- a/config/openshift/kustomization.yaml
+++ b/config/openshift/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - scc.yaml

--- a/config/openshift/scc.yaml
+++ b/config/openshift/scc.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: samba-scc
+  name: samba
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: true
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+readOnlyRootFilesystem: false
+requiredDropCapabilities: null
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+volumes:
+  - "*"

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -214,7 +214,7 @@ rules:
   - apiGroups:
       - security.openshift.io
     resourceNames:
-      - anyuid
+      - samba
     resources:
       - securitycontextconstraints
     verbs:

--- a/controllers/smbcommonconfig_controller.go
+++ b/controllers/smbcommonconfig_controller.go
@@ -44,7 +44,7 @@ type SmbCommonConfigReconciler struct {
 // +kubebuilder:rbac:groups=core,resources=pods;endpoints;services;namespaces,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,verbs=get;list;use
-// +kubebuilder:rbac:groups=security.openshift.io,resourceNames=anyuid,resources=securitycontextconstraints,verbs=get;list;create;update
+// +kubebuilder:rbac:groups=security.openshift.io,resourceNames=samba,resources=securitycontextconstraints,verbs=get;list;create;update
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;create;update
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors;prometheusrules,verbs=get;list;watch;create;update
 

--- a/controllers/smbcommonconfig_controller.go
+++ b/controllers/smbcommonconfig_controller.go
@@ -32,7 +32,7 @@ import (
 type SmbCommonConfigReconciler struct {
 	client.Client
 	Log         logr.Logger
-	ClusterType resources.ClusterType
+	ClusterType string
 }
 
 //revive:disable kubebuilder directives
@@ -60,7 +60,7 @@ func (r *SmbCommonConfigReconciler) Reconcile(
 	// 1) Unknown cluster type due to first-time reconcile
 	// 2) Known to be running over OpenShift by in-memory cached state from
 	//    previous reconcile loop.
-	if r.ClusterType != "" && r.ClusterType != resources.ClusterTypeOpenshift {
+	if r.ClusterType != "" && r.ClusterType != conf.ClusterTypeOpenShift {
 		return ctrl.Result{}, nil
 	}
 

--- a/controllers/smbcommonconfig_controller.go
+++ b/controllers/smbcommonconfig_controller.go
@@ -24,15 +24,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	sambaoperatorv1alpha1 "github.com/samba-in-kubernetes/samba-operator/api/v1alpha1"
-	"github.com/samba-in-kubernetes/samba-operator/internal/conf"
-	"github.com/samba-in-kubernetes/samba-operator/internal/resources"
 )
 
 // SmbCommonConfigReconciler reconciles a SmbCommonConfig object
 type SmbCommonConfigReconciler struct {
 	client.Client
-	Log         logr.Logger
-	ClusterType string
+	Log logr.Logger
 }
 
 //revive:disable kubebuilder directives
@@ -43,8 +40,6 @@ type SmbCommonConfigReconciler struct {
 // +kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=pods;endpoints;services;namespaces,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=get;list;watch;create;update;delete
-// +kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,verbs=get;list;use
-// +kubebuilder:rbac:groups=security.openshift.io,resourceNames=samba,resources=securitycontextconstraints,verbs=get;list;create;update
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;create;update
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors;prometheusrules,verbs=get;list;watch;create;update
 
@@ -52,34 +47,11 @@ type SmbCommonConfigReconciler struct {
 
 // Reconcile SmbCommonConfig resources.
 func (r *SmbCommonConfigReconciler) Reconcile(
-	ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	_ context.Context, req ctrl.Request) (ctrl.Result, error) {
 	// ---
 	log := r.Log.WithValues("smbcommonconfig", req.NamespacedName)
-
-	// Process OpenShift logic in one of two states:
-	// 1) Unknown cluster type due to first-time reconcile
-	// 2) Known to be running over OpenShift by in-memory cached state from
-	//    previous reconcile loop.
-	if r.ClusterType != "" && r.ClusterType != conf.ClusterTypeOpenShift {
-		return ctrl.Result{}, nil
-	}
-
-	mgr := resources.NewOpenShiftManager(r.Client, log, conf.Get())
-	res := mgr.Process(ctx, req.NamespacedName)
-	err := res.Err()
-	if res.Requeue() {
-		return ctrl.Result{Requeue: true}, err
-	}
-
-	// Cache in-memory cluster-type to avoid extra network round-trips in next
-	// reconcile phase.
-	if r.ClusterType == "" {
-		r.Log.Info("Saving discovered cluster type",
-			"ClusterType", mgr.ClusterType)
-		r.ClusterType = mgr.ClusterType
-	}
-
-	return ctrl.Result{}, err
+	log.Info("Reconcile SmbCommonConfig")
+	return ctrl.Result{}, nil
 }
 
 // SetupWithManager sets up resource management.

--- a/controllers/smbshare_controller.go
+++ b/controllers/smbshare_controller.go
@@ -52,6 +52,9 @@ type SmbShareReconciler struct {
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=events,verbs=create
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;delete
+// +kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,verbs=get;list;use
+// +kubebuilder:rbac:groups=security.openshift.io,resourceNames=samba,resources=securitycontextconstraints,verbs=get;list;create;update
+// +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors;prometheusrules,verbs=get;list;watch;create;update
 
 //revive:enable
 

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -9,6 +9,13 @@ import (
 	"github.com/spf13/viper"
 )
 
+const (
+	// ClusterTypeDefault defines the default value for cluster type
+	ClusterTypeDefault = "default"
+	// ClusterTypeOpenShift defines the type-name for OpenShift clusters
+	ClusterTypeOpenShift = "openshift"
+)
+
 // DefaultOperatorConfig holds the default values of OperatorConfig.
 var DefaultOperatorConfig = OperatorConfig{
 	SmbdContainerImage:        "quay.io/samba.org/samba-server:latest",
@@ -25,6 +32,7 @@ var DefaultOperatorConfig = OperatorConfig{
 	MetricsExporterMode:       "disabled",
 	ImagePullPolicy:           "IfNotPresent",
 	DefaultNodeSelector:       "",
+	ClusterType:               "",
 }
 
 // OperatorConfig is a type holding general configuration values.
@@ -83,6 +91,10 @@ type OperatorConfig struct {
 	// a set of key-value pairs that will be used for all default node
 	// selection. If left blank, internal defaults will be used.
 	DefaultNodeSelector string `mapstructure:"default-node-selector"`
+	// ClusterType is a string which defines the type of underlying K8S
+	// cluster (minikube, OpenShift etc). If not provided, the operator will
+	// try to figure it out.
+	ClusterType string `mapstructure:"cluster-type"`
 }
 
 // Validate the OperatorConfig returning an error if the config is not
@@ -134,6 +146,7 @@ func NewSource() *Source {
 	v.SetDefault("pod-ip", d.PodIP)
 	v.SetDefault("image-pull-policy", d.ImagePullPolicy)
 	v.SetDefault("default-node-selector", d.DefaultNodeSelector)
+	v.SetDefault("cluster-type", d.ClusterType)
 	return &Source{v: v}
 }
 

--- a/internal/resources/deployments.go
+++ b/internal/resources/deployments.go
@@ -42,6 +42,9 @@ func buildDeployment(cfg *conf.OperatorConfig,
 			Name:      planner.InstanceName(),
 			Namespace: ns,
 			Labels:    labels,
+			Annotations: map[string]string{
+				"openshift.io/scc": sambaSccName,
+			},
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &size,
@@ -91,6 +94,7 @@ func annotationsForSmbPod(cfg *conf.OperatorConfig) map[string]string {
 	annotations := map[string]string{
 		"kubectl.kubernetes.io/default-logs-container": name,
 		"kubectl.kubernetes.io/default-container":      name,
+		"openshift.io/scc":                             sambaSccName,
 	}
 	if withMetricsExporter(cfg) {
 		for k, v := range annotationsForSmbMetricsPod() {

--- a/internal/resources/openshift.go
+++ b/internal/resources/openshift.go
@@ -41,7 +41,7 @@ const (
 
 // OpenShiftManager is used to manage OpenShift's related resources: SCC,
 // ServiceAccount (if not exists) and enable Role and RoleBinding referencing
-// to OpenShift's 'anyuid' SCC.
+// to OpenShift's 'samba' SCC.
 type OpenShiftManager struct {
 	client      rtclient.Client
 	logger      logr.Logger
@@ -419,7 +419,7 @@ func (m *OpenShiftManager) getOrCreateSCCRole(
 				// TODO: ask John if he prefers import openshift for those vals
 				APIGroups:     []string{"security.openshift.io"},
 				Resources:     []string{"securitycontextconstraints"},
-				ResourceNames: []string{"anyuid"},
+				ResourceNames: []string{"samba"},
 				Verbs:         []string{"use"},
 			},
 		},

--- a/internal/resources/pods.go
+++ b/internal/resources/pods.go
@@ -482,6 +482,7 @@ func buildSmbdCtr(
 				},
 			},
 		},
+		SecurityContext: ctrPrivSecurityContext(),
 	}
 }
 
@@ -589,6 +590,7 @@ func buildSvcWatchCtr(
 		Name:            "svc-watch",
 		Env:             env,
 		VolumeMounts:    mounts,
+		SecurityContext: ctrPrivSecurityContext(),
 	}
 }
 
@@ -621,6 +623,7 @@ func buildEnsureShareCtr(
 		Args:            planner.Args().EnsureSharePaths(),
 		Env:             env,
 		VolumeMounts:    mounts,
+		SecurityContext: ctrPrivSecurityContext(),
 	}
 }
 
@@ -837,4 +840,11 @@ func imagePullPolicy(pl *pln.Planner) corev1.PullPolicy {
 		pullPolicy = corev1.PullIfNotPresent
 	}
 	return pullPolicy
+}
+
+func ctrPrivSecurityContext() *corev1.SecurityContext {
+	return &corev1.SecurityContext{
+		Privileged:   &[]bool{true}[0],
+		RunAsNonRoot: &[]bool{false}[0],
+	}
 }

--- a/internal/resources/pods.go
+++ b/internal/resources/pods.go
@@ -783,10 +783,20 @@ func metaPodEnv() []corev1.EnvVar {
 
 func defaultPodSpec(planner *pln.Planner) corev1.PodSpec {
 	shareProcessNamespace := true
+	sambaServiceAccountName, automountServiceAccountToken := podServiceAccount(planner)
 	return corev1.PodSpec{
-		ServiceAccountName:    planner.GlobalConfig.ServiceAccountName,
-		ShareProcessNamespace: &shareProcessNamespace,
+		ServiceAccountName:           sambaServiceAccountName,
+		AutomountServiceAccountToken: automountServiceAccountToken,
+		ShareProcessNamespace:        &shareProcessNamespace,
 	}
+}
+
+func podServiceAccount(planner *pln.Planner) (string, *bool) {
+	if planner.GlobalConfig.ClusterType == conf.ClusterTypeOpenShift {
+		automountServiceAccountToken := true
+		return sambaServiceAccountName, &automountServiceAccountToken
+	}
+	return "default", nil
 }
 
 func ctdbHostnameEnv(_ *pln.Planner) []corev1.EnvVar {

--- a/internal/resources/smbshare.go
+++ b/internal/resources/smbshare.go
@@ -122,6 +122,10 @@ func (m *SmbShareManager) Update(
 		return Requeue
 	}
 
+	if result := m.updateForOpenshift(ctx, instance); result.Yield() {
+		return result
+	}
+
 	// assign the share to a Server Group. The server group represents
 	// the resources needed to create samba servers (possibly a cluster)
 	// and prerequisite resources. The serverGroup name used to name
@@ -489,6 +493,10 @@ func (m *SmbShareManager) Finalize(
 	}
 
 	if result := m.finalizeServerResources(ctx, instance); result.Yield() {
+		return result
+	}
+
+	if result := m.finalizeForOpenshift(ctx, instance); result.Yield() {
 		return result
 	}
 

--- a/internal/resources/smbshare.go
+++ b/internal/resources/smbshare.go
@@ -184,7 +184,11 @@ func (m *SmbShareManager) Update(
 		return result
 	}
 
-	m.logger.Info("Done updating SmbShare resources")
+	m.logger.Info(
+		"Done updating SmbShare resources",
+		"SmbShare.Namespace", instance.Namespace,
+		"SmbShare.Name", instance.Name,
+		"Annotations", instance.Annotations)
 	return Done
 }
 


### PR DESCRIPTION
Refactor deployment over OpenShift cluster using custom `samba` SCC. User is expected to deploy the `samba` SCC prior to the deployment of the samba-operator (or, via kustomization mechanism). 

Reconcile ServiceAccount, Role and RoleBinding as part of SmbShare reconcile loop, within the namespace in which the smbshare resides.