### PR TITLE
tests/centosci: Increase disk size of minikube VMs

### DIFF
--- a/tests/centosci/sink-common.sh
+++ b/tests/centosci/sink-common.sh
@@ -21,7 +21,7 @@ NODE_COUNT=${NODE_COUNT:-"3"}
 MEMORY=${MEMORY:-"4096"}
 CPUS=${CPUS:-"2"}
 NUM_DISKS=${NUM_DISKS:-"2"}
-DISK_SIZE=${DISK_SIZE:-"10g"}
+DISK_SIZE=${DISK_SIZE:-"15g"}
 DISK_CONFIG=${DISK_CONFIG:-" --extra-disks=${NUM_DISKS} --disk-size=${DISK_SIZE}"}
 
 image_pull() {


### PR DESCRIPTION
With more recent versions of Kubernetes, cluster setup seems to consume more space leading to the edge of required percentage of available space(default 30%) on the file system used by monitor database. Therefore increase the disk capacity to 15G.

```
Status:
  Ceph:
    Capacity:
      Bytes Available:  63043710976
      Bytes Total:      64424509440
      Bytes Used:       1380798464
      Last Updated:     2023-06-19T12:00:15Z
    Details:
      MON_DISK_LOW:
        Message:   mon a is low on available space
        Severity:  HEALTH_WARN
    Fsid:          e91d9c48-129a-4ced-b626-402901563c69
    Health:        HEALTH_WARN
    Last Checked:  2023-06-19T12:00:15Z
```