### PR TITLE
kustomize: replace patchesStrategicMerge with patches

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
   - bases/samba-operator.samba.org_smbsecurityconfigs.yaml
   - bases/samba-operator.samba.org_smbcommonconfigs.yaml
   # +kubebuilder:scaffold:crdkustomizeresource
-patchesStrategicMerge:
+patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
 #- patches/webhook_in_smbshares.yaml

--- a/config/manager-full/kustomization.yaml
+++ b/config/manager-full/kustomization.yaml
@@ -2,11 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../manager
-patchesStrategicMerge:
+patches:
   # Protect the /metrics endpoint by putting it behind auth.
   # If you want your controller-manager to expose the /metrics
   # endpoint w/o any authn/z, please comment the following line.
-  - auth_proxy_patch.yaml
+  - path: auth_proxy_patch.yaml
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml


### PR DESCRIPTION
kustomize v5.0.0 deprecated `patchesStrategicMerge`, it's renamed to `patches`. Normally it just gives a warning, but some tools like Argocd will treat this as error.
https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/patchesstrategicmerge/