### PR TITLE
Bump minimum Go version to 1.19

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.18"
+          go-version: "1.19"
       - uses: actions/checkout@v3
       - name: Build
         run: make
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.18"
+          go-version: "1.19"
       - uses: actions/checkout@v3
       - name: Install revive
         run: go install github.com/mgechev/revive@latest
@@ -46,7 +46,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.18"
+          go-version: "1.19"
       - uses: actions/checkout@v3
       - name: run the tests
         run: make test
@@ -100,7 +100,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.18"
+          go-version: "1.19"
       - name: Install k3d
         run: curl -L --silent --fail "https://raw.githubusercontent.com/rancher/k3d/main/install.sh" | bash
       # The TAG env var can interfere with the k3d install script.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM docker.io/golang:1.18 as builder
+FROM docker.io/golang:1.19 as builder
 ARG GIT_VERSION="(unset)"
 ARG COMMIT_ID="(unset)"
 ARG ARCH=""

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -17,7 +17,7 @@ resources.
 Development effort takes place using Linux environment and requires at
 minimum:
 
-1. [Go 1.18](https://golang.org/dl/) installed
+1. [Go 1.19](https://golang.org/dl/) installed
 2. [GitHub](https://github.com/) account
 3. Development tools: git, make, and podman or docker
 4. Testing: [minikube](https://minikube.sigs.k8s.io)

--- a/docs/developers-notes.md
+++ b/docs/developers-notes.md
@@ -4,7 +4,7 @@
 ## Build from source
 
 The top-level [Makefile](../Makefile) is the entry point for various build
-commands. The minimal required Go version is 1.18. A developer can verify the
+commands. The minimal required Go version is 1.19. A developer can verify the
 build environment by running:
 
 ```bash

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/samba-in-kubernetes/samba-operator
 
-go 1.18
+go 1.19
 
 require (
 	github.com/go-logr/logr v1.2.3

--- a/tests/centosci/sink-clustered-deployment.sh
+++ b/tests/centosci/sink-clustered-deployment.sh
@@ -13,7 +13,7 @@ setup_minikube
 
 deploy_rook
 
-image_pull "${CI_IMG_REGISTRY}" "docker.io" "golang:1.18"
+image_pull "${CI_IMG_REGISTRY}" "docker.io" "golang:1.19"
 
 # Build and push operator image to local CI registry
 IMG="${CI_IMG_OP}" make image-build


### PR DESCRIPTION
depends on https://github.com/samba-in-kubernetes/samba-centosci/pull/28