### PR TITLE
workflows: use symbolic name in go-version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.19"
+          go-version: oldstable
       - uses: actions/checkout@v3
       - name: Build
         run: make
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.19"
+          go-version: oldstable
       - uses: actions/checkout@v3
       - name: Install revive
         run: go install github.com/mgechev/revive@latest
@@ -46,7 +46,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.19"
+          go-version: oldstable
       - uses: actions/checkout@v3
       - name: run the tests
         run: make test
@@ -100,7 +100,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.19"
+          go-version: oldstable
       - name: Install k3d
         run: curl -L --silent --fail "https://raw.githubusercontent.com/rancher/k3d/main/install.sh" | bash
       # The TAG env var can interfere with the k3d install script.


### PR DESCRIPTION
Depends on: #313 
Depends on: #288 


The workflow files that use Go directly (as opposed to inside a container) use actions/setup-go - this action gained an ability to use "relative versions" of `stable` and `oldstable` in the last year or two.

Switch our workflow file to use `oldstable` rather than a specific version number in order to keep up with releases from Go upstream. Use `oldstable` as to ensure the older but still actively maintained version of Go works.

This doesn't handle the container image... that's a WIP project for another PR.