### PR TITLE
hack: add go-version-check.sh script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM docker.io/golang:1.19 as builder
+FROM docker.io/golang:1.20 as builder
 ARG GIT_VERSION="(unset)"
 ARG COMMIT_ID="(unset)"
 ARG ARCH=""

--- a/Makefile
+++ b/Makefile
@@ -206,9 +206,9 @@ bundle-build:
 	@false
 	# See vcs history for how this could be restored or adapted in the future.
 
-.PHONY: check check-revive check-golangci-lint check-format check-yaml check-gosec
+.PHONY: check check-revive check-golangci-lint check-format check-yaml check-gosec check-dockerfile-go-version
 
-check: check-revive check-golangci-lint check-format vet check-yaml check-gosec
+check: check-revive check-golangci-lint check-format vet check-yaml check-gosec check-dockerfile-go-version
 
 check-format:
 	! $(GOFMT_CMD) $(CHECK_GOFMT_FLAGS) . | sed 's,^,formatting error: ,' | grep 'go$$'
@@ -226,6 +226,10 @@ check-yaml:
 
 check-gosec: gosec
 	$(GOSEC) -quiet -exclude=G101 -fmt json ./...
+
+check-dockerfile-go-version:
+	# use go-version-check.sh --show to list vaild golang builder images
+	$(CURDIR)/hack/go-version-check.sh --check
 
 check-gitlint: gitlint
 	$(GITLINT) -C .gitlint --commits origin/master.. lint

--- a/hack/go-version-check.sh
+++ b/hack/go-version-check.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+#
+# List or check that the golang version embedded in files (specifically our
+# Dockerfile) is using a supported version of Go.
+# Run with --show to list the images the script thinks are current.
+# Run with --check (the default) to verify the Dockerfile contains a current
+# image & version tag.
+#
+
+set -e
+SCRIPT_DIR="$(readlink -f "$(dirname "${0}")")"
+PROJECT_DIR="$(readlink -f "${SCRIPT_DIR}/..")"
+WORKDIR="$(mktemp -d)"
+CONTAINER_FILES=("${PROJECT_DIR}/Dockerfile")
+GOVERSURL='https://go.dev/dl/?mode=json'
+ACTION=check
+
+
+fetch_versions() {
+    local url="$1"
+    local out="$2"
+    if [ -f "${out}" ]; then
+        return
+    fi
+    echo "Fetching Go versions..." >&2
+    curl --fail -sL -o "${out}" "${url}"
+}
+
+extract_versions() {
+    local jsonfile="$1"
+    jq -r '.[].version' < "${jsonfile}" | \
+        cut -d. -f1,2 | sort -u | sed -e 's,^go,,'
+}
+
+to_images() {
+    for a in "$@"; do
+        echo "docker.io/golang:${a}"
+    done
+}
+
+cleanup() {
+    # only used in trap, ignoe unreachable error
+    # shellcheck disable=SC2317
+    rm -rf "${WORKDIR}"
+}
+trap cleanup EXIT
+
+
+opts=$(getopt --name "$0" \
+    -o "csf:" -l "check,show,file:,url:,versionsfile:" -- "$@")
+eval set -- "$opts"
+
+cli_cfiles=()
+while true ; do
+    case "$1" in
+        -c|--check)
+            ACTION=check
+            shift
+        ;;
+        -s|--show)
+            ACTION=show
+            shift
+        ;;
+        -f|--file)
+            cli_cfiles+=("$2")
+            shift 2
+        ;;
+        --url)
+            GOVERSURL="$2"
+            shift 2
+        ;;
+        --versionsfile)
+            GOVERSIONSFILE="$2"
+            shift 2
+        ;;
+        --)
+            shift
+            break
+        ;;
+        *)
+            echo "unexpected option: $1" >&2
+            exit 2
+        ;;
+    esac
+done
+
+if [ "${#cli_cfiles}" -gt 0 ]; then
+    CONTAINER_FILES=("${cli_cfiles[@]}")
+fi
+
+GV="${GOVERSIONSFILE:-${WORKDIR}/go-versions.json}"
+fetch_versions "${GOVERSURL}" "${GV}"
+mapfile -t go_major_vers < <(extract_versions "${GV}")
+
+echo "Found Go versions:" "${go_major_vers[@]}" >&2
+if [ "${ACTION}" = show ]; then
+    to_images "${go_major_vers[@]}"
+    exit 1
+fi
+
+mapfile -t valid_images < <(to_images "${go_major_vers[@]}")
+errors=0
+for cf in "${CONTAINER_FILES[@]}"; do
+    echo "Checking $cf ..." >&2
+    if grep -q -e "${valid_images[0]}" -e "${valid_images[1]}" "${cf}" ; then
+        echo "${cf}: OK" >&2
+    else
+        echo "${cf}: no current golang image found" >&2
+        errors=1
+    fi
+done
+
+exit "${errors}"


### PR DESCRIPTION
Related to, but not blocked on, #314 

Add a script that validates the Dockefile (or other specified container files) or shows the list of current supported golang version images. The goal is to ensure we are continually using a supported Go version and not falling behind.

Add a new check-dockerfile-go-version makefile target and include it in the check target. This runs the recently added script to validate the version of golang used to build in container.

The downside of this approach is that PRs & other work unrelated to Golang may periodically break when Go issues a new major release.
Let's try this for now and if it ends up getting really annoying we can try to do some other form of automation to alert us to the need of a version bump that doesn't interfere with unrelated work.