### PR TITLE
centosci: Update golang pre-pulled image version to 1.20

### DIFF
--- a/tests/centosci/sink-clustered-deployment.sh
+++ b/tests/centosci/sink-clustered-deployment.sh
@@ -13,7 +13,7 @@ setup_minikube
 
 deploy_rook
 
-image_pull "${CI_IMG_REGISTRY}" "docker.io" "golang:1.19"
+image_pull "${CI_IMG_REGISTRY}" "docker.io" "golang:1.20"
 
 # Build and push operator image to local CI registry
 IMG="${CI_IMG_OP}" make image-build


### PR DESCRIPTION
Following the commit https://github.com/samba-in-kubernetes/samba-operator/commit/1d9f821610e7d0aade0ff2c73e8fcd82091f44dd to use updated(v1.20) golang base container image for building operator CI registry now mirrors golang:1.20 which can be consumed within corresponding script running integration tests on CentOS CI.

depends on https://github.com/samba-in-kubernetes/samba-centosci/pull/46