### PR TITLE
config: restrict deployments to amd64 nodes

### DIFF
--- a/config/manager-full/auth_proxy_patch.yaml
+++ b/config/manager-full/auth_proxy_patch.yaml
@@ -8,6 +8,15 @@ metadata:
 spec:
   template:
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
       containers:
         - name: kube-rbac-proxy
           # this is apparently the same code as

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -31,6 +31,15 @@ spec:
         kubectl.kubernetes.io/default-logs-container: manager
         kubectl.kubernetes.io/default-container: manager
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
       containers:
         - command:
             - /manager


### PR DESCRIPTION
Until samba-operator supports other architectures (namely, ARM64), restrict its deployment to AMD64 nodes (e.g., in cases of non x86_64 or mixed ARCH clusters) via standard K8s node-selector mechanism [1].

[1] https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/

depends on #329 