### PR TITLE
resources: fix case of nil PodAntiAffinity

### DIFF
--- a/internal/resources/statefulsets.go
+++ b/internal/resources/statefulsets.go
@@ -81,9 +81,10 @@ func buildOneSmbdPerNodeAffinity(
 
 	affinity := affinityForSmbPod(planner)
 	if affinity == nil {
-		affinity = &corev1.Affinity{
-			PodAntiAffinity: &corev1.PodAntiAffinity{},
-		}
+		affinity = &corev1.Affinity{}
+	}
+	if affinity.PodAntiAffinity == nil {
+		affinity.PodAntiAffinity = &corev1.PodAntiAffinity{}
 	}
 	affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution = append(
 		affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution,


### PR DESCRIPTION
Protect from case where user provided 'affinity' entry in podSettings of smbcommonconfig but without 'podAntiAffinity' sub-entry. This in turn would cause samba-operator a nil pointer dereference.

Fixes: https://github.com/samba-in-kubernetes/samba-operator/issues/330