### PR TITLE
tests/centosci: Update mirrored golang image to 1.21

### DIFF
--- a/tests/centosci/sink-clustered-deployment.sh
+++ b/tests/centosci/sink-clustered-deployment.sh
@@ -13,7 +13,7 @@ setup_minikube
 
 deploy_rook
 
-image_pull "${CI_IMG_REGISTRY}" "docker.io" "golang:1.20"
+image_pull "${CI_IMG_REGISTRY}" "docker.io" "golang:1.21"
 
 # Build and push operator image to local CI registry
 IMG="${CI_IMG_OP}" make image-build


### PR DESCRIPTION
depends on https://github.com/samba-in-kubernetes/samba-centosci/pull/55