### PR TITLE
workflows: Update actions to avoid Node.js warning

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,20 +11,20 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version: oldstable
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build
         run: make
   # Run static/code-quality checks
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version: oldstable
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install revive
         run: go install github.com/mgechev/revive@latest
       - name: Run checks
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
@@ -44,10 +44,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version: oldstable
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: run the tests
         run: make test
   podmanbuild:
@@ -56,7 +56,7 @@ jobs:
     # image build step, so no need to do it twice.
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install fuse-overlayfs
         run: sudo apt-get -y install fuse-overlayfs
       - name: Setup podman config
@@ -84,7 +84,7 @@ jobs:
     # image build step, so no need to do it twice.
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: build container image
         # note: forcing use of podman here since we are
         # using podman explicitly for the push job
@@ -97,8 +97,8 @@ jobs:
       CONTAINER_CMD: docker
       PR_NUM: ${{ github.event.pull_request.number }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: oldstable
       - name: Install k3d
@@ -152,7 +152,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: log in to quay.io
         # using docker for now, since podman has an issue with space
         # consumption: image build fails with no space left on device...


### PR DESCRIPTION
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/setup-go@v3, actions/checkout@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

Use updated versions for [setup-go](https://github.com/actions/setup-go/releases/tag/v5.0.0) and [checkout](https://github.com/actions/checkout/releases/tag/v4.0.0) to get rid of the above warnings.