### PR TITLE
`make check` updates to cope with oldest stable version go1.22

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -9,7 +9,7 @@ linters:
     - dupl
     - errcheck
     - exhaustive
-    - exportloopref
+    - copyloopvar
     - funlen
     # - gci
     - goconst
@@ -23,7 +23,6 @@ linters:
     # - ineffassign
     # - ifshort
     - lll
-    - megacheck
     - misspell
     # - nlreturn
     # - nolintlint
@@ -42,7 +41,6 @@ linters-settings:
     lines: 188
     statements: 60
   govet:
-    check-shadowing: true
     enable-all: true
     disable:
       - fieldalignment

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM docker.io/golang:1.21 as builder
+FROM docker.io/golang:1.22 as builder
 ARG GIT_VERSION="(unset)"
 ARG COMMIT_ID="(unset)"
 ARG ARCH=""

--- a/hack/install-tools.sh
+++ b/hack/install-tools.sh
@@ -44,7 +44,7 @@ _install_revive() {
 }
 
 _install_golangci_lint() {
-	_install_tool github.com/golangci/golangci-lint/cmd/golangci-lint@v1.53.3
+	_install_tool github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.2
 }
 
 _install_yq() {

--- a/hack/install-tools.sh
+++ b/hack/install-tools.sh
@@ -52,7 +52,7 @@ _install_yq() {
 }
 
 _install_gosec() {
-	_install_tool github.com/securego/gosec/v2/cmd/gosec@v2.13.1
+	_install_tool github.com/securego/gosec/v2/cmd/gosec@v2.20.0
 }
 
 _install_gitlint() {

--- a/internal/resources/smbshare.go
+++ b/internal/resources/smbshare.go
@@ -851,7 +851,7 @@ func (m *SmbShareManager) setServerGroup(
 				EventWarning,
 				ReasonInvalidConfiguration,
 				msg)
-			return false, fmt.Errorf(msg)
+			return false, fmt.Errorf("%s", msg)
 		}
 	case pln.GroupModeExplicit:
 		if reqGroupName == "" {
@@ -861,7 +861,7 @@ func (m *SmbShareManager) setServerGroup(
 				EventWarning,
 				ReasonInvalidConfiguration,
 				msg)
-			return false, fmt.Errorf(msg)
+			return false, fmt.Errorf("%s", msg)
 		}
 		serverGroup = reqGroupName
 	default:
@@ -871,7 +871,7 @@ func (m *SmbShareManager) setServerGroup(
 			EventWarning,
 			ReasonInvalidConfiguration,
 			msg)
-		return false, fmt.Errorf(msg)
+		return false, fmt.Errorf("%s", msg)
 	}
 
 	s.Status.ServerGroup = serverGroup


### PR DESCRIPTION
go1.23 has been released which demands updates to various components.

**_golangci-lint_**
- We happened to observe the panic from the linked issue #344 which should be fixed with latest _golangci-lint_ versions. 
- The linter 'exportloopref' is deprecated (since v1.60.2) due to: Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar.
- The linter named \"megacheck\" is deprecated. It has been split into: gosimple, staticcheck, unused.
- The configuration option `linters.govet.check-shadowing` is deprecated. Please enable `shadow` instead, if you are not using `enable-all`.
- Additional fixes to make new `govet` happy.

**_gosec_**
We happened to observe the panic from the linked issue #344 which should be fixed with latest _gosec_ versions. 

**_go-version-check.sh_**
Update _Dockerfile_ to reflect the oldest stable version go1.22 so as to pass `make check-dockerfile-go-version`.

fixes #344 