### PR TITLE
tests/centosci: Update mirrored golang image to 1.22

### DIFF
--- a/tests/centosci/sink-clustered-deployment.sh
+++ b/tests/centosci/sink-clustered-deployment.sh
@@ -13,7 +13,7 @@ setup_minikube
 
 deploy_rook
 
-image_pull "${CI_IMG_REGISTRY}" "docker.io" "golang:1.21"
+image_pull "${CI_IMG_REGISTRY}" "docker.io" "golang:1.22"
 
 # Build and push operator image to local CI registry
 IMG="${CI_IMG_OP}" make image-build


### PR DESCRIPTION
Latest minor updates([v1.31.1](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.31.md#feature), [v1.30.5](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.30.md#feature), [v1.29.9](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.29.md#feature)) for supported kubernetes releases calls for golang version update as they are built with _go1.22.6_.