### PR TITLE
go.mod: Bump Go version to 1.23.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM docker.io/golang:1.22 as builder
+FROM docker.io/golang:1.23 as builder
 ARG GIT_VERSION="(unset)"
 ARG COMMIT_ID="(unset)"
 ARG ARCH=""

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/samba-in-kubernetes/samba-operator
 
-go 1.19
+go 1.23.0
 
 require (
 	github.com/go-logr/logr v1.2.3


### PR DESCRIPTION
It is really unfortunate that golang has decided to come up with an [automation](https://github.com/golang/go/issues/69095) to update `go` directive in _go.mod_ from various repositories including x/repos following the release cadence in general. Another interesting and visible change is to explicitly specify the minor version as a suffix to the major version. Thus we are bound to update our `go` directive as we require many of the golang x/repos.