### PR TITLE
Add support for setting StorageClass for state pvc

### DIFF
--- a/api/v1alpha1/smbcommonconfig_types.go
+++ b/api/v1alpha1/smbcommonconfig_types.go
@@ -38,6 +38,11 @@ type SmbCommonConfigSpec struct {
 	// under PodSettings allow admins and users to customize how pods
 	// are scheduled in a kubernetes cluster.
 	PodSettings *SmbCommonConfigPodSettings `json:"podSettings,omitempty"`
+
+	// StateSCName specifies which StorageClass is to be used for this share.
+	// If left empty, the operator's default will be used.
+	// +optional
+	StatePVSCName string `json:"statePVSCName,omitempty"`
 }
 
 // SmbCommonNetworkSpec values define networking properties for the services

--- a/config/crd/bases/samba-operator.samba.org_smbcommonconfigs.yaml
+++ b/config/crd/bases/samba-operator.samba.org_smbcommonconfigs.yaml
@@ -510,6 +510,9 @@ spec:
                       description: NodeSelector values will be assigned to a PodSpec's NodeSelector.
                       type: object
                   type: object
+                statePVSCName:
+                  description: StateSCName specifies which StorageClass is to be used for this share. If left empty, the operator's default will be used.
+                  type: string
               type: object
             status:
               description: SmbCommonConfigStatus defines the observed state of SmbCommonConfig

--- a/internal/resources/getters.go
+++ b/internal/resources/getters.go
@@ -119,6 +119,11 @@ func (m *SmbShareManager) getOrCreateStatePVC(
 			},
 		},
 	}
+
+	if planner.CommonConfig.Spec.StatePVSCName != "" {
+		spec.StorageClassName = &planner.CommonConfig.Spec.StatePVSCName
+	}
+
 	pvc, cr, err := m.getOrCreateGenericPVC(
 		ctx, planner.SmbShare, spec, name, ns)
 	if err != nil {


### PR DESCRIPTION
Add a new field statePVSCName in SmbCommonConfig.spec that allows users to specify StorageClass for Samba StatefulSet's state PVC in ctdb cluster mode. If not set, state PVC uses default StorageClass as before.
For example:
```
  spec:
    network:
      publish: external
    statePVSCName: samba-operator-system-samba-service-storageclass
```

Refs #340 