### PR TITLE
workflows: use ubuntu-latest on all jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
       - name: run the tests
         run: make test
   podmanbuild:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     # don't run on push, since the "push" job contains the
     # image build step, so no need to do it twice.
     if: github.event_name == 'pull_request'
@@ -91,8 +91,7 @@ jobs:
         run: make CONTAINER_CMD=docker image-build
   test-kubernetes:
     #runs-on: ubuntu-latest
-    # need to explicitly use 20.04 to avoid problems with jq...
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       CONTAINER_CMD: docker
       PR_NUM: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
GitHub has retired 20.04 and jobs using it no longer run.