### PR TITLE
mergify: Restrict the addition of "priority-review" label

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -83,6 +83,8 @@ pull_request_rules:
     conditions:
       - "updated-at<15 days ago"
       - "-draft"
+      - "-closed"
+      - "-merged"
     actions:
       label:
         add:


### PR DESCRIPTION
Mergify rules doesn't check the status of pull requests before adding the "priority-review" label. In addition to the existing rules it only makes sense to add the label if the pull request is in open state.