### PR TITLE
Update basic tools and environment for go1.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM docker.io/golang:1.23 as builder
+FROM docker.io/golang:1.24 as builder
 ARG GIT_VERSION="(unset)"
 ARG COMMIT_ID="(unset)"
 ARG ARCH=""

--- a/hack/install-tools.sh
+++ b/hack/install-tools.sh
@@ -44,7 +44,7 @@ _install_revive() {
 }
 
 _install_golangci_lint() {
-	_install_tool github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.2
+	_install_tool github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8
 }
 
 _install_yq() {

--- a/hack/install-tools.sh
+++ b/hack/install-tools.sh
@@ -36,7 +36,7 @@ _install_kustomize() {
 }
 
 _install_controller_gen() {
-	_install_tool sigs.k8s.io/controller-tools/cmd/controller-gen@v0.14.0
+	_install_tool sigs.k8s.io/controller-tools/cmd/controller-gen@v0.19.0
 }
 
 _install_revive() {

--- a/hack/install-tools.sh
+++ b/hack/install-tools.sh
@@ -52,7 +52,7 @@ _install_yq() {
 }
 
 _install_gosec() {
-	_install_tool github.com/securego/gosec/v2/cmd/gosec@v2.20.0
+	_install_tool github.com/securego/gosec/v2/cmd/gosec@v2.22.9
 }
 
 _install_gitlint() {

--- a/internal/planner/properties.go
+++ b/internal/planner/properties.go
@@ -99,7 +99,7 @@ func (pl *Planner) ClusterSize() int32 {
 	if pl.SmbShare.Spec.Scaling == nil {
 		return 1
 	}
-	return int32(pl.SmbShare.Spec.Scaling.MinClusterSize)
+	return int32(pl.SmbShare.Spec.Scaling.MinClusterSize) // #nosec G115
 }
 
 // Grouping returns the logical grouping mode and group name.

--- a/internal/resources/metrics.go
+++ b/internal/resources/metrics.go
@@ -53,7 +53,7 @@ func buildSmbMetricsContainer(image string,
 		Name:    "samba-metrics",
 		Command: []string{"/bin/smbmetrics"},
 		Ports: []corev1.ContainerPort{{
-			ContainerPort: int32(portnum),
+			ContainerPort: int32(portnum), // #nosec G115 – safe constant 8080
 			Name:          "smbmetrics",
 		}},
 		VolumeMounts: volmnts,
@@ -111,11 +111,11 @@ func (m *SmbShareManager) getOrCreateMetricsService(
 			Ports: []corev1.ServicePort{
 				{
 					Name:     defaultMetricsPortName,
-					Port:     int32(defaultMetricsPort),
+					Port:     int32(defaultMetricsPort), // #nosec G115 – safe constant 8080
 					Protocol: corev1.ProtocolTCP,
 					TargetPort: intstr.IntOrString{
 						Type:   intstr.Int,
-						IntVal: int32(defaultMetricsPort),
+						IntVal: int32(defaultMetricsPort), // #nosec G115 – safe constant 8080
 					},
 				},
 			},

--- a/internal/resources/pods.go
+++ b/internal/resources/pods.go
@@ -464,7 +464,7 @@ func buildSmbdCtr(
 		Args:            planner.Args().Run("smbd"),
 		Env:             env,
 		Ports: []corev1.ContainerPort{{
-			ContainerPort: int32(portnum),
+			ContainerPort: int32(portnum), // #nosec G115 – safe constant 445
 			Name:          "smb",
 		}},
 		VolumeMounts: mounts,

--- a/internal/resources/services.go
+++ b/internal/resources/services.go
@@ -36,9 +36,11 @@ func newServiceForSmb(planner *pln.Planner, ns string) *corev1.Service {
 		Spec: corev1.ServiceSpec{
 			Type: toServiceType(planner.ServiceType()),
 			Ports: []corev1.ServicePort{{
-				Name:       "smb",
-				Protocol:   corev1.ProtocolTCP,
-				Port:       int32(planner.GlobalConfig.SmbServicePort),
+				Name:     "smb",
+				Protocol: corev1.ProtocolTCP,
+				// revive:disable:line-length-limit gosec rule ignore
+				Port: int32(planner.GlobalConfig.SmbServicePort), // #nosec G115 – safe constant 445
+				// revive:enable:line-length-limit
 				TargetPort: intstr.FromInt(planner.GlobalConfig.SmbdPort),
 			}},
 			Selector: map[string]string{

--- a/internal/resources/smbshare.go
+++ b/internal/resources/smbshare.go
@@ -373,7 +373,9 @@ func (m *SmbShareManager) updateClusteredState(
 
 	resized, err := m.updateStatefulSetSize(
 		ctx, statefulSet,
-		int32(planner.SmbShare.Spec.Scaling.MinClusterSize))
+		// revive:disable:line-length-limit gosec rule ignore
+		int32(planner.SmbShare.Spec.Scaling.MinClusterSize)) // #nosec G115
+	// revive:enable:line-length-limit
 	if err != nil {
 		return Result{err: err}
 	}

--- a/tests/integration/scheduling_test.go
+++ b/tests/integration/scheduling_test.go
@@ -193,6 +193,9 @@ func (s *NodeSelectorSuite) createSmbCommonConfig(ctx context.Context) {
 					"mytestid":           s.testID,
 				},
 			},
+			Network: sambaoperatorv1alpha1.SmbCommonNetworkSpec{
+				Publish: "external",
+			},
 		},
 	}
 	err := s.tc.TypedObjectClient().Create(ctx, cc)
@@ -273,6 +276,9 @@ func (s *AffinityBasedSelectorSuite) createSmbCommonConfig(ctx context.Context) 
 						}},
 					},
 				},
+			},
+			Network: sambaoperatorv1alpha1.SmbCommonNetworkSpec{
+				Publish: "external",
 			},
 		},
 	}


### PR DESCRIPTION
- [go1.25](https://go.dev/blog/go1.25) is now available making go1.24 the oldest supported release. Accordingly update the Dockerfile to make _go-version-check.sh_ happy.
- Bump `golangci-lint` and `gosec` to a version that supports go1.24 (and go1.25).
- Update `controller-gen` to support also go1.25.