### PR TITLE
hack: Update controller-gen to v0.19.0

### DIFF
--- a/hack/install-tools.sh
+++ b/hack/install-tools.sh
@@ -36,7 +36,7 @@ _install_kustomize() {
 }
 
 _install_controller_gen() {
-	_install_tool sigs.k8s.io/controller-tools/cmd/controller-gen@v0.14.0
+	_install_tool sigs.k8s.io/controller-tools/cmd/controller-gen@v0.19.0
 }
 
 _install_revive() {


### PR DESCRIPTION
With go1.25, there's a [breaking change](https://github.com/golang/go/issues/74462) from _golang.org/x/tools_ pulled in by controller tools for which a fix is available in either v0.24.1 (and above) or v0.25.1 (and above). This minimum version of _golang.org/x/tools_ is only included from controller tools v0.16.4. We make use of this opportunity to fetch the latest version.