### PR TITLE
buildSmbMetricsContainer: pass --port to smbmetrics container

### DIFF
--- a/internal/resources/metrics.go
+++ b/internal/resources/metrics.go
@@ -52,6 +52,7 @@ func buildSmbMetricsContainer(image string,
 		Image:   image,
 		Name:    "samba-metrics",
 		Command: []string{"/bin/smbmetrics"},
+		Args:    []string{fmt.Sprintf("--port=%d", portnum)},
 		Ports: []corev1.ContainerPort{{
 			ContainerPort: int32(portnum), // #nosec G115 – safe constant 8080
 			Name:          "smbmetrics",

--- a/internal/resources/metrics_test.go
+++ b/internal/resources/metrics_test.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package resources
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestBuildSmbMetricsContainer(t *testing.T) {
+	ctr := buildSmbMetricsContainer("quay.io/samba.org/samba-metrics:latest", nil, nil)
+
+	t.Run("name", func(t *testing.T) {
+		assert.Equal(t, "samba-metrics", ctr.Name)
+	})
+
+	t.Run("image", func(t *testing.T) {
+		assert.Equal(t, "quay.io/samba.org/samba-metrics:latest", ctr.Image)
+	})
+
+	t.Run("portArgMatchesProbes", func(t *testing.T) {
+		// The --port arg passed to the binary must match the port used by the
+		// liveness and readiness probes, otherwise the probes always fail and
+		// the container enters a CrashLoopBackOff.
+		expectedArg := fmt.Sprintf("--port=%d", defaultMetricsPort)
+		assert.Contains(t, ctr.Args, expectedArg,
+			"smbmetrics binary must receive --port matching the probe port")
+
+		assert.Equal(t, int32(defaultMetricsPort),
+			ctr.LivenessProbe.TCPSocket.Port.IntVal,
+			"liveness probe port must match --port arg")
+		assert.Equal(t, int32(defaultMetricsPort),
+			ctr.ReadinessProbe.TCPSocket.Port.IntVal,
+			"readiness probe port must match --port arg")
+	})
+
+	t.Run("containerPort", func(t *testing.T) {
+		assert.Len(t, ctr.Ports, 1)
+		assert.Equal(t, int32(defaultMetricsPort), ctr.Ports[0].ContainerPort)
+		assert.Equal(t, "smbmetrics", ctr.Ports[0].Name)
+	})
+
+	t.Run("envAndMounts", func(t *testing.T) {
+		env := []corev1.EnvVar{{Name: "FOO", Value: "bar"}}
+		mounts := []corev1.VolumeMount{{Name: "vol", MountPath: "/mnt"}}
+		ctr2 := buildSmbMetricsContainer("img", env, mounts)
+		assert.Equal(t, env, ctr2.Env)
+		assert.Equal(t, mounts, ctr2.VolumeMounts)
+	})
+}


### PR DESCRIPTION
This fix is about buildSmbMetricsContainer in internal/resources/metrics.go: when the smbmetrics sidecar container is enabled, the samba share pod always crashes (CrashLoopBackoff).

buildSmbMetricsContainer() configures liveness and readiness probes on port 8080 but does not pass --port to the smbmetrics binary, which defaults to port 9922. The probes therefore always fail, putting the samba-metrics sidecar into a CrashLoopBackOff immediately after startup.

Fixed by passing --port= as an argument so the binary listens on the same port the probes expect.

This fix was tested on a live k3s cluster:

```kubectl get pods -n samba -o custom-columns='NAME:.metadata.name,STATUS:.status.phase,CONTAINERS:.spec.containers[*].name'
NAME                           STATUS    CONTAINERS
storage-6695849ccc-vgcph       Running   samba,watch-update-config,samba-metrics
timemachine-6cb85c447d-7fs9f   Running   samba,watch-update-config,samba-metrics```