### PR TITLE
dockerfile: update go version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM docker.io/golang:1.24 as builder
+FROM docker.io/golang:1.25 as builder
 ARG GIT_VERSION="(unset)"
 ARG COMMIT_ID="(unset)"
 ARG ARCH=""


### PR DESCRIPTION
The go version embedded in the dockerfile has fallen out of date, bump it up.