### PR TITLE
resources: support PVC sub paths deeper than one level

### DIFF
--- a/api/v1alpha1/smbshare_types.go
+++ b/api/v1alpha1/smbshare_types.go
@@ -101,7 +101,9 @@ type SmbSharePvcSpec struct {
 	Spec *corev1.PersistentVolumeClaimSpec `json:"spec,omitempty"`
 
 	// Path within the PVC which should be exported.
-	// +kubebuilder:validation:Pattern=`^[^\/]+$`
+	// Must be a relative path. Path traversal ("..") is not allowed.
+	// +kubebuilder:validation:Pattern=`^[^\/].*$`
+	// +kubebuilder:validation:XValidation:rule="!self.matches('(^|\/)\.\.(\/|$)')",message="path must not contain '..' traversal"
 	// +optional
 	Path string `json:"path,omitempty"`
 }

--- a/internal/planner/paths.go
+++ b/internal/planner/paths.go
@@ -18,6 +18,7 @@ package planner
 import (
 	"fmt"
 	"path"
+	"strings"
 )
 
 // Paths for relevant files and dirs within the containers.
@@ -44,10 +45,16 @@ func (p *Paths) ShareMountPath() string {
 // Share path.
 func (p *Paths) Share() string {
 	sharepath := p.planner.SmbShare.Spec.Storage.Pvc.Path
-	if sharepath != "" {
-		return path.Join(p.ShareMountPath(), "/", sharepath)
+	if sharepath == "" {
+		return p.ShareMountPath()
 	}
-	return p.ShareMountPath()
+	mountPath := p.ShareMountPath()
+	joined := path.Join(mountPath, sharepath)
+	// Ensure the resolved path stays within the mount path
+	if !strings.HasPrefix(joined, mountPath+"/") && joined != mountPath {
+		return mountPath
+	}
+	return joined
 }
 
 // ContainerConfigs returns a slice containing all configuration


### PR DESCRIPTION
There does not seem to be a technical limitation for doing this, other than complexity involving path validation. This uses a defense-in-depth approach with an (admittedly somewhat complex) regex to prevent path escapes, coupled with a manual bounds check if the CR is applied without validation.