### PR TITLE
go.mod: update go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/samba-in-kubernetes/samba-operator
 
-go 1.23.0
+go 1.25.11
 
 require (
 	github.com/go-logr/logr v1.2.3


### PR DESCRIPTION
Update go version to align with the one in the Dockerfile, which was updated in #372 but not in go.mod